### PR TITLE
feat: accounting module, offramp gas controls & 1inch direct-to-Kraken

### DIFF
--- a/docs/ideas/backend-safe-architecture.md
+++ b/docs/ideas/backend-safe-architecture.md
@@ -1,0 +1,49 @@
+# Idea: Backend Safe as Operator Wallet
+
+## Problem
+
+The current setup has the backend EOA (`WALLET_PRIVATE_KEY`) directly owning and executing transactions for each user Safe. Every offramp operation is a separate on-chain transaction signed by the EOA — one gas payment per user per step.
+
+## Idea
+
+Introduce a **backend Safe** controlled by the backend EOA, and make that Safe the owner of all user Safes instead.
+
+```
+Backend EOA
+    └── Backend Safe (operator)
+            ├── User Safe A
+            ├── User Safe B
+            └── User Safe C
+```
+
+## How It Would Work
+
+- At user Safe deployment, set the **backend Safe address** as the sole owner (instead of the raw EOA)
+- The backend Safe signs for user Safes via **EIP-1271** contract signatures — fully supported by the Safe Protocol Kit
+- The backend EOA signs once on the backend Safe, which authorises actions on any number of child Safes
+
+## Key Benefits
+
+### Batching across user Safes
+Use **MultiSend** on the backend Safe to batch operations across multiple user Safes in a single EOA signature and gas payment. For example, 10 offramp transfers in one transaction instead of 10.
+
+### Single signing surface
+The EOA only ever interacts with the backend Safe. All user Safe authorisations flow through it — easier key rotation, easier access control.
+
+### Audit trail
+Every action across all user Safes is visible as a transaction on the backend Safe, giving a clean operator-level audit log.
+
+### Future: spending limits / modules
+The backend Safe can be extended with Safe modules (e.g. spending limit module, allowance module) to automate recurring operations without requiring a full Safe signature each time.
+
+## What Would Change in Code
+
+- `safe.service.ts` — `initSdkForAddress` would use the backend Safe as the contract signer (EIP-1271) rather than the raw private key
+- `ensureDeployed` — pass the backend Safe address as owner at deployment instead of `this.wallet.address`
+- `executeManyRaw` / `executeTransfer` — build the user Safe tx, sign with backend Safe, then execute via backend Safe
+
+The processor and strategy logic would be unchanged — the batching opportunity lives entirely in `SafeService`.
+
+## When to Do This
+
+Worth implementing once transaction volume justifies it. For low volume it adds complexity without meaningful savings.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,8 +27,12 @@ model User {
   bankAccounts       BankAccount[]
   offRampRoutes      OffRampRoute[]
   userWallets        UserWallet[]
-  walletAuthSessions WalletAuthSession[]
-  invoices           Invoice[]
+  walletAuthSessions   WalletAuthSession[]
+  invoices             Invoice[]
+  accountingAddresses      AccountingAddress[]
+  accountingBlacklist      AccountingBlacklist[]
+  accountingAccounts       AccountingAccount[]
+  classificationTemplates  ClassificationTemplate[]
 }
 
 // ---------------------------------------------------------------------------
@@ -351,6 +355,181 @@ model AlchemyCache {
 
   @@unique([requestType, parameters])
   @@index([expiresAt])
+}
+
+// ---------------------------------------------------------------------------
+// Accounting
+// ---------------------------------------------------------------------------
+
+enum AccountType {
+  ASSET
+  LIABILITY
+  EQUITY
+  REVENUE
+  EXPENSE
+}
+
+enum NormalBalance {
+  DEBIT
+  CREDIT
+}
+
+enum JournalLineType {
+  DEBIT
+  CREDIT
+}
+
+enum TransferClassification {
+  ASSET
+  LIABILITY
+  SWAP_IN
+  SWAP_OUT
+  PAYMENT
+  RECEIVED
+  TRANSFER
+  SKIPPED
+  UNCLASSIFIED
+}
+
+model AccountingAddress {
+  id           String    @id @default(cuid())
+  userId       String
+  address      String
+  label        String?
+  chain        String    // Alchemy chain slug, e.g. "eth-mainnet"
+  chainId      Int
+  lastSyncedAt DateTime?
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
+
+  user      User                 @relation(fields: [userId], references: [id], onDelete: Cascade)
+  transfers AccountingTransfer[]
+
+  @@unique([userId, address, chainId])
+  @@index([userId])
+  @@map("accounting_addresses")
+}
+
+model AccountingTransfer {
+  id                  String                 @id @default(cuid())
+  accountingAddressId String
+  chainId             Int
+  txHash              String
+  alchemyUniqueId     String                 // e.g. "<txHash>:log:<logIndex>"
+  blockNum            String                 // hex string from Alchemy
+  blockNumber         Int?                   // parsed integer for sorting
+  logIndex            Int?                   // parsed from alchemyUniqueId for intra-block ordering
+  timestamp           DateTime?
+  direction           String                 // "IN" | "OUT"
+  tokenAddress        String?
+  tokenSymbol         String?
+  tokenDecimals       Int?
+  tokenType           String                 // "erc20", "external", etc.
+  amountRaw           String?
+  amountFormatted     String?
+  fromAddress         String
+  toAddress           String?
+  classification      TransferClassification @default(UNCLASSIFIED)
+  isHidden            Boolean                @default(false)
+  chfValue            String?                // manually entered CHF equivalent
+  notes               String?
+  createdAt           DateTime               @default(now())
+  updatedAt           DateTime               @updatedAt
+
+  accountingAddress AccountingAddress @relation(fields: [accountingAddressId], references: [id], onDelete: Cascade)
+  journalEntry      JournalEntry?
+
+  @@unique([accountingAddressId, alchemyUniqueId])
+  @@index([accountingAddressId])
+  @@index([classification])
+  @@map("accounting_transfers")
+}
+
+model AccountingBlacklist {
+  id            String   @id @default(cuid())
+  tokenAddress  String
+  chainId       Int
+  tokenSymbol   String?
+  reason        String?
+  addedByUserId String
+  createdAt     DateTime @default(now())
+
+  addedBy User @relation(fields: [addedByUserId], references: [id])
+
+  @@unique([tokenAddress, chainId])
+  @@map("accounting_blacklist")
+}
+
+model AccountingAccount {
+  id            String        @id @default(cuid())
+  userId        String
+  name          String
+  code          String?
+  type          AccountType
+  normalBalance NormalBalance
+  description   String?
+  createdAt     DateTime      @default(now())
+  updatedAt     DateTime      @updatedAt
+
+  user              User                     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  journalLines      JournalLine[]
+  debitTemplates    ClassificationTemplate[] @relation("TemplateDebit")
+  creditTemplates   ClassificationTemplate[] @relation("TemplateCredit")
+
+  @@unique([userId, name])
+  @@index([userId])
+  @@map("accounting_accounts")
+}
+
+model JournalEntry {
+  id          String   @id @default(cuid())
+  transferId  String   @unique
+  date        DateTime
+  description String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  transfer AccountingTransfer @relation(fields: [transferId], references: [id], onDelete: Cascade)
+  lines    JournalLine[]
+
+  @@map("journal_entries")
+}
+
+model JournalLine {
+  id             String          @id @default(cuid())
+  journalEntryId String
+  accountId      String
+  type           JournalLineType
+  amount         String
+  chfAmount      String?
+  tokenSymbol    String?
+  createdAt      DateTime        @default(now())
+
+  journalEntry JournalEntry      @relation(fields: [journalEntryId], references: [id], onDelete: Cascade)
+  account      AccountingAccount @relation(fields: [accountId], references: [id])
+
+  @@index([journalEntryId])
+  @@index([accountId])
+  @@map("journal_lines")
+}
+
+model ClassificationTemplate {
+  id             String                 @id @default(cuid())
+  userId         String
+  classification TransferClassification
+  direction      String                 @default("ANY") // "IN" | "OUT" | "ANY"
+  debitAccountId  String
+  creditAccountId String
+  createdAt      DateTime               @default(now())
+  updatedAt      DateTime               @updatedAt
+
+  user          User              @relation(fields: [userId], references: [id], onDelete: Cascade)
+  debitAccount  AccountingAccount @relation("TemplateDebit",  fields: [debitAccountId],  references: [id])
+  creditAccount AccountingAccount @relation("TemplateCredit", fields: [creditAccountId], references: [id])
+
+  @@unique([userId, classification, direction])
+  @@index([userId])
+  @@map("classification_templates")
 }
 
 // ---------------------------------------------------------------------------

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,10 +29,11 @@ model User {
   userWallets        UserWallet[]
   walletAuthSessions   WalletAuthSession[]
   invoices             Invoice[]
-  accountingAddresses      AccountingAddress[]
-  accountingBlacklist      AccountingBlacklist[]
-  accountingAccounts       AccountingAccount[]
-  classificationTemplates  ClassificationTemplate[]
+  accountingAddresses       AccountingAddress[]
+  accountingBlacklist       AccountingBlacklist[]
+  accountingAccounts        AccountingAccount[]
+  classificationTemplates   ClassificationTemplate[]
+  counterpartyLabels        AccountingCounterpartyLabel[]
 }
 
 // ---------------------------------------------------------------------------
@@ -380,6 +381,14 @@ enum JournalLineType {
 }
 
 enum TransferClassification {
+  // New classifications
+  CAPITAL
+  INCOME
+  LOAN
+  REPAYMENT
+  EXPENSE
+  NEUTRAL
+  // Existing (kept for backwards compat with accounting module)
   ASSET
   LIABILITY
   SWAP_IN
@@ -402,8 +411,10 @@ model AccountingAddress {
   createdAt    DateTime  @default(now())
   updatedAt    DateTime  @updatedAt
 
-  user      User                 @relation(fields: [userId], references: [id], onDelete: Cascade)
-  transfers AccountingTransfer[]
+  user         User                     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  transfers    AccountingTransfer[]
+  adjustments  AccountingAdjustment[]
+  tokenPrices  AccountingTokenPrice[]
 
   @@unique([userId, address, chainId])
   @@index([userId])
@@ -443,6 +454,55 @@ model AccountingTransfer {
   @@index([accountingAddressId])
   @@index([classification])
   @@map("accounting_transfers")
+}
+
+model AccountingCounterpartyLabel {
+  id        String   @id @default(cuid())
+  userId    String
+  address   String   // lowercase hex
+  label     String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, address])
+  @@index([userId])
+  @@map("accounting_counterparty_labels")
+}
+
+model AccountingTokenPrice {
+  id                  String   @id @default(cuid())
+  accountingAddressId String
+  year                Int
+  tokenSymbol         String
+  priceChf            String
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
+
+  accountingAddress AccountingAddress @relation(fields: [accountingAddressId], references: [id], onDelete: Cascade)
+
+  @@unique([accountingAddressId, year, tokenSymbol])
+  @@index([accountingAddressId])
+  @@map("accounting_token_prices")
+}
+
+model AccountingAdjustment {
+  id                  String   @id @default(cuid())
+  accountingAddressId String
+  date                DateTime @default(now())
+  type                String   // 'PROFIT' | 'LOSS' | 'CORRECTION'
+  tokenSymbol         String?
+  amount              String?
+  chfValue            String?
+  note                String?
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
+
+  accountingAddress AccountingAddress @relation(fields: [accountingAddressId], references: [id], onDelete: Cascade)
+
+  @@index([accountingAddressId])
+  @@map("accounting_adjustments")
 }
 
 model AccountingBlacklist {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -43,6 +43,7 @@ import { AdminSettingsModule } from './modules/admin-settings/admin-settings.mod
 import { OffRampExecutionsModule } from './modules/offramp-executions/offramp-executions.module';
 import { UserWalletsModule } from './modules/user-wallets/user-wallets.module';
 import { InvoicesModule } from './modules/invoices/invoices.module';
+import { AccountingModule } from './modules/accounting/accounting.module';
 
 // Core modules
 import { OffRampCoreModule } from './core/offramp/offramp-core.module';
@@ -135,6 +136,7 @@ import { AppService } from './app.service';
     UserWalletsModule,
     EventsModule,
     InvoicesModule,
+    AccountingModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/core/offramp/offramp.processor.ts
+++ b/src/core/offramp/offramp.processor.ts
@@ -8,7 +8,7 @@ import type { Address } from 'viem';
 import { FiatCurrency } from '@prisma/client';
 import { PrismaService } from '../database/prisma.service';
 import { SafeService } from '../../integrations/safe/safe.service';
-import { WalletViemService } from '../../integrations/wallet/wallet.viem.service';
+import { WalletViemService, GasTooHighError } from '../../integrations/wallet/wallet.viem.service';
 import { OneInchService } from '../../integrations/oneinch/oneinch.service';
 import { KrakenDeposit } from '../../integrations/kraken/kraken.deposit';
 import { KrakenOrders } from '../../integrations/kraken/kraken.orders';
@@ -31,6 +31,8 @@ const DEPOSIT_POLL_DELAY_MS = 30_000;
 const DEPOSIT_POLL_MAX_ATTEMPTS = 240; // 2 hours
 const WITHDRAWAL_POLL_DELAY_MS = 60_000;
 const WITHDRAWAL_POLL_MAX_ATTEMPTS = 60; // 1 hour
+const GAS_RETRY_DELAY_MS = 5 * 60_000; // 5 minutes
+const GAS_RETRY_MAX_ATTEMPTS = 72; // 6 hours
 
 @Processor(OFFRAMP_QUEUE)
 export class OffRampProcessor extends WorkerHost {
@@ -86,6 +88,16 @@ export class OffRampProcessor extends WorkerHost {
           this.logger.warn(`Execution ${executionId} in terminal status ${execution.status} — skipping`);
       }
     } catch (err) {
+      if (err instanceof GasTooHighError) {
+        const attempt = (job.data.gasRetryAttempt ?? 0) + 1;
+        if (attempt <= GAS_RETRY_MAX_ATTEMPTS) {
+          this.logger.warn(`Execution ${executionId}: ${err.message} (retry ${attempt}/${GAS_RETRY_MAX_ATTEMPTS})`);
+          await this.queue.add(OFFRAMP_QUEUE, { executionId, gasRetryAttempt: attempt }, { delay: GAS_RETRY_DELAY_MS });
+          return;
+        }
+        this.logger.error(`Execution ${executionId}: gas remained too high after ${GAS_RETRY_MAX_ATTEMPTS} retries — failing`);
+      }
+
       const error = err instanceof Error ? err.message : String(err);
       this.logger.error(`Execution ${executionId} failed at ${execution.status}: ${error}`);
       await this.prisma.offRampExecution.update({
@@ -124,6 +136,17 @@ export class OffRampProcessor extends WorkerHost {
 
     const amount = parseUnits(execution.tokenAmount.toString(), tokenConfig.decimals);
 
+    await this.viem.conservativeGasFees(chainId);
+
+    // If the strategy outputs a Kraken-mapped token, route the swap directly to the Kraken
+    // deposit address — this saves one on-chain transfer from the Safe.
+    let krakenRecipient: Address | undefined;
+    if (strategy.outputSymbol && KRAKEN_DEPOSIT_ASSET[strategy.outputSymbol]) {
+      const depositAddress = await this.resolveKrakenDepositAddress(strategy.outputSymbol);
+      krakenRecipient = getAddress(depositAddress) as Address;
+      this.logger.log(`Routing ${strategy.outputSymbol} swap output directly to Kraken deposit address ${depositAddress}`);
+    }
+
     this.logger.log(`Converting ${execution.tokenAmount} ${execution.tokenSymbol} via strategy (safe: ${safeWallet.address})`);
 
     await this.prisma.offRampExecution.update({
@@ -139,32 +162,42 @@ export class OffRampProcessor extends WorkerHost {
       getAddress(safeWallet.address) as Address,
       chainId,
       amount,
+      krakenRecipient,
     );
 
     const outputDecimals = result.tokenSymbol === 'ETH'
       ? 18
       : (ENABLED_TOKENS.find((t) => t.symbol === result.tokenSymbol)?.decimals ?? 18);
 
+    const outputAmount = formatUnits(result.amount, outputDecimals);
+
     await this.prisma.offRampExecution.update({
       where: { id: execution.id },
       data: {
         conversionTxHash: result.txHash,
         krakenTokenSymbol: result.tokenSymbol,
-        krakenTokenAmount: formatUnits(result.amount, outputDecimals),
+        krakenTokenAmount: outputAmount,
       },
     });
 
-    const outputAmount = formatUnits(result.amount, outputDecimals);
     this.logger.log(`Conversion complete: ${execution.tokenSymbol} → ${result.tokenSymbol} (${outputAmount}) tx: ${result.txHash}`);
     this.notifyUser(execution.userId, 'Converted', `${execution.tokenAmount} ${execution.tokenSymbol} → ${outputAmount} ${result.tokenSymbol}`);
 
-    // Re-fetch with updated krakenToken fields then proceed to transfer
-    const updated = await this.prisma.offRampExecution.findUnique({
-      where: { id: execution.id },
-      include: { route: { include: { safeWallet: true, bankAccount: true } } },
-    });
-
-    await this.handleTransfer(updated);
+    if (krakenRecipient) {
+      // Funds landed directly at Kraken — no separate Safe→Kraken transfer needed
+      await this.prisma.offRampExecution.update({
+        where: { id: execution.id },
+        data: { status: 'TRANSFERRING', onChainTxHash: result.txHash },
+      });
+      await this.enqueueNext(execution.id, DEPOSIT_POLL_DELAY_MS);
+    } else {
+      // Funds are still in the Safe — do the normal transfer step
+      const updated = await this.prisma.offRampExecution.findUnique({
+        where: { id: execution.id },
+        include: { route: { include: { safeWallet: true, bankAccount: true } } },
+      });
+      await this.handleTransfer(updated);
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -179,30 +212,9 @@ export class OffRampProcessor extends WorkerHost {
     const krakenSymbol: string = execution.krakenTokenSymbol ?? execution.tokenSymbol;
     const krakenAmount: string = execution.krakenTokenAmount?.toString() ?? execution.tokenAmount.toString();
 
-    const krakenAsset = KRAKEN_DEPOSIT_ASSET[krakenSymbol];
-    if (!krakenAsset) {
-      throw new Error(`Token ${krakenSymbol} has no Kraken deposit mapping. Add a conversion strategy or update KRAKEN_DEPOSIT_ASSET.`);
-    }
+    await this.viem.conservativeGasFees(safeWallet.chainId);
 
-    const methodHint = KRAKEN_DEPOSIT_METHOD_HINT[krakenSymbol];
-    const methodsRes = await this.krakenDeposit.getMethods(OPERATOR, { asset: krakenAsset });
-    if (methodsRes.error?.length) throw new Error(`Kraken deposit methods error: ${methodsRes.error.join(', ')}`);
-
-    this.logger.log(`Kraken deposit methods for ${krakenAsset}: ${methodsRes.result.map((m) => m.method).join(', ')}`);
-
-    const method = methodsRes.result.find((m) =>
-      m.method.toUpperCase().includes(methodHint.toUpperCase()),
-    );
-    if (!method) throw new Error(`No deposit method found for ${krakenAsset}. Available: ${methodsRes.result.map((m) => m.method).join(', ')}`);
-
-    const addrRes = await this.krakenDeposit.getAddresses(OPERATOR, {
-      asset: krakenAsset,
-      method: method.method,
-    });
-    if (addrRes.error?.length) throw new Error(`Kraken deposit address error: ${addrRes.error.join(', ')}`);
-
-    const depositAddress = addrRes.result[0]?.address;
-    if (!depositAddress) throw new Error('No Kraken deposit address available');
+    const depositAddress = await this.resolveKrakenDepositAddress(krakenSymbol);
 
     this.logger.log(`Transferring ${krakenAmount} ${krakenSymbol} from Safe ${safeWallet.address} to Kraken ${depositAddress}`);
 
@@ -403,6 +415,29 @@ export class OffRampProcessor extends WorkerHost {
   // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------
+  private async resolveKrakenDepositAddress(krakenSymbol: string): Promise<string> {
+    const krakenAsset = KRAKEN_DEPOSIT_ASSET[krakenSymbol];
+    if (!krakenAsset) {
+      throw new Error(`Token ${krakenSymbol} has no Kraken deposit mapping. Add a conversion strategy or update KRAKEN_DEPOSIT_ASSET.`);
+    }
+
+    const methodHint = KRAKEN_DEPOSIT_METHOD_HINT[krakenSymbol];
+    const methodsRes = await this.krakenDeposit.getMethods(OPERATOR, { asset: krakenAsset });
+    if (methodsRes.error?.length) throw new Error(`Kraken deposit methods error: ${methodsRes.error.join(', ')}`);
+
+    this.logger.log(`Kraken deposit methods for ${krakenAsset}: ${methodsRes.result.map((m) => m.method).join(', ')}`);
+
+    const method = methodsRes.result.find((m) => m.method.toUpperCase().includes(methodHint.toUpperCase()));
+    if (!method) throw new Error(`No deposit method found for ${krakenAsset}. Available: ${methodsRes.result.map((m) => m.method).join(', ')}`);
+
+    const addrRes = await this.krakenDeposit.getAddresses(OPERATOR, { asset: krakenAsset, method: method.method });
+    if (addrRes.error?.length) throw new Error(`Kraken deposit address error: ${addrRes.error.join(', ')}`);
+
+    const address = addrRes.result[0]?.address;
+    if (!address) throw new Error('No Kraken deposit address available');
+    return address;
+  }
+
   private async enqueueNext(executionId: string, delayMs: number, pollAttempt = 0) {
     await this.queue.add(
       OFFRAMP_QUEUE,

--- a/src/core/offramp/offramp.processor.ts
+++ b/src/core/offramp/offramp.processor.ts
@@ -8,449 +8,605 @@ import type { Address } from 'viem';
 import { FiatCurrency } from '@prisma/client';
 import { PrismaService } from '../database/prisma.service';
 import { SafeService } from '../../integrations/safe/safe.service';
-import { WalletViemService, GasTooHighError } from '../../integrations/wallet/wallet.viem.service';
+import {
+	WalletViemService,
+	GasTooHighError,
+} from '../../integrations/wallet/wallet.viem.service';
 import { OneInchService } from '../../integrations/oneinch/oneinch.service';
 import { KrakenDeposit } from '../../integrations/kraken/kraken.deposit';
 import { KrakenOrders } from '../../integrations/kraken/kraken.orders';
 import { KrakenWithdraw } from '../../integrations/kraken/kraken.withdraw';
-import { NotificationEvent, AdminNotificationEvent } from '../../common/events/notification.events';
+import {
+	NotificationEvent,
+	AdminNotificationEvent,
+} from '../../common/events/notification.events';
 import { ENABLED_TOKENS } from '../../config/tokens.config';
 import { ConversionStrategyRegistry } from './strategies/conversion-strategy.registry';
 import {
-  OFFRAMP_QUEUE,
-  OffRampJobData,
-  KRAKEN_DEPOSIT_ASSET,
-  KRAKEN_DEPOSIT_METHOD_HINT,
-  KRAKEN_FIAT_ASSET,
-  KRAKEN_WITHDRAW_KEY_ENV,
-  krakenPairFor,
+	OFFRAMP_QUEUE,
+	OffRampJobData,
+	KRAKEN_DEPOSIT_ASSET,
+	KRAKEN_DEPOSIT_METHOD_HINT,
+	KRAKEN_FIAT_ASSET,
+	KRAKEN_WITHDRAW_KEY_ENV,
+	krakenPairFor,
 } from './offramp.queue';
 
 const OPERATOR = 'operator';
-const DEPOSIT_POLL_DELAY_MS = 30_000;
-const DEPOSIT_POLL_MAX_ATTEMPTS = 240; // 2 hours
+const DEPOSIT_POLL_DELAY_MS = 60_000;
+const DEPOSIT_POLL_MAX_ATTEMPTS = 7_200; // 5 days
 const WITHDRAWAL_POLL_DELAY_MS = 60_000;
-const WITHDRAWAL_POLL_MAX_ATTEMPTS = 60; // 1 hour
+const WITHDRAWAL_POLL_MAX_ATTEMPTS = 7_200; // 5 days
 const GAS_RETRY_DELAY_MS = 5 * 60_000; // 5 minutes
-const GAS_RETRY_MAX_ATTEMPTS = 72; // 6 hours
+const GAS_RETRY_MAX_ATTEMPTS = 1_440; // 5 days
 
 @Processor(OFFRAMP_QUEUE)
 export class OffRampProcessor extends WorkerHost {
-  private readonly logger = new Logger(OffRampProcessor.name);
-
-  constructor(
-    private readonly prisma: PrismaService,
-    private readonly safe: SafeService,
-    private readonly viem: WalletViemService,
-    private readonly oneinch: OneInchService,
-    private readonly registry: ConversionStrategyRegistry,
-    private readonly krakenDeposit: KrakenDeposit,
-    private readonly krakenOrders: KrakenOrders,
-    private readonly krakenWithdraw: KrakenWithdraw,
-    private readonly configService: ConfigService,
-    private readonly eventEmitter: EventEmitter2,
-    @InjectQueue(OFFRAMP_QUEUE) private readonly queue: Queue<OffRampJobData>,
-  ) {
-    super();
-  }
-
-  async process(job: Job<OffRampJobData>): Promise<void> {
-    const { executionId } = job.data;
-
-    const execution = await this.prisma.offRampExecution.findUnique({
-      where: { id: executionId },
-      include: { route: { include: { safeWallet: true, bankAccount: true } } },
-    });
-
-    if (!execution) {
-      this.logger.warn(`Execution ${executionId} not found — skipping`);
-      return;
-    }
-
-    try {
-      switch (execution.status) {
-        case 'DETECTED':
-          await this.handleDetected(execution);
-          break;
-        case 'TRANSFERRING':
-          await this.handleWaitDeposit(execution, job.data.pollAttempt ?? 0);
-          break;
-        case 'DEPOSITED':
-          await this.handleSell(execution);
-          break;
-        case 'SOLD':
-          await this.handleWithdraw(execution);
-          break;
-        case 'WITHDRAWING':
-          await this.handleCheckWithdrawal(execution, job.data.pollAttempt ?? 0);
-          break;
-        default:
-          this.logger.warn(`Execution ${executionId} in terminal status ${execution.status} — skipping`);
-      }
-    } catch (err) {
-      if (err instanceof GasTooHighError) {
-        const attempt = (job.data.gasRetryAttempt ?? 0) + 1;
-        if (attempt <= GAS_RETRY_MAX_ATTEMPTS) {
-          this.logger.warn(`Execution ${executionId}: ${err.message} (retry ${attempt}/${GAS_RETRY_MAX_ATTEMPTS})`);
-          await this.queue.add(OFFRAMP_QUEUE, { executionId, gasRetryAttempt: attempt }, { delay: GAS_RETRY_DELAY_MS });
-          return;
-        }
-        this.logger.error(`Execution ${executionId}: gas remained too high after ${GAS_RETRY_MAX_ATTEMPTS} retries — failing`);
-      }
-
-      const error = err instanceof Error ? err.message : String(err);
-      this.logger.error(`Execution ${executionId} failed at ${execution.status}: ${error}`);
-      await this.prisma.offRampExecution.update({
-        where: { id: executionId },
-        data: { status: 'FAILED', error },
-      });
-      this.notifyUser(execution.userId, 'Off-ramp failed', `Your off-ramp could not be completed: ${error}`, 'error');
-      this.notifyAdmin('Off-ramp execution failed', `Execution \`${executionId}\` failed at status \`${execution.status}\`\n\nError: ${error}`, 'error');
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Step 1a DETECTED — route to conversion or direct transfer
-  // ---------------------------------------------------------------------------
-  private async handleDetected(execution: any) {
-    this.notifyUser(execution.userId, 'Received', `${execution.tokenAmount} ${execution.tokenSymbol} received.`);
-    const strategy = this.registry.get(execution.tokenSymbol);
-    if (strategy) {
-      await this.handleConvert(execution, strategy);
-    } else {
-      await this.handleTransfer(execution);
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Step 1b DETECTED → CONVERTING → (ready for TRANSFERRING)
-  // Run a pre-deposit conversion strategy (unwrap, swap, redeem, …)
-  // ---------------------------------------------------------------------------
-  private async handleConvert(execution: any, strategy: any) {
-    const { route } = execution;
-    const { safeWallet } = route;
-    const chainId = safeWallet.chainId;
-
-    const tokenConfig = ENABLED_TOKENS.find((t) => t.symbol === execution.tokenSymbol);
-    if (!tokenConfig) throw new Error(`Token ${execution.tokenSymbol} not found in config`);
-
-    const amount = parseUnits(execution.tokenAmount.toString(), tokenConfig.decimals);
-
-    await this.viem.conservativeGasFees(chainId);
-
-    // If the strategy outputs a Kraken-mapped token, route the swap directly to the Kraken
-    // deposit address — this saves one on-chain transfer from the Safe.
-    let krakenRecipient: Address | undefined;
-    if (strategy.outputSymbol && KRAKEN_DEPOSIT_ASSET[strategy.outputSymbol]) {
-      const depositAddress = await this.resolveKrakenDepositAddress(strategy.outputSymbol);
-      krakenRecipient = getAddress(depositAddress) as Address;
-      this.logger.log(`Routing ${strategy.outputSymbol} swap output directly to Kraken deposit address ${depositAddress}`);
-    }
-
-    this.logger.log(`Converting ${execution.tokenAmount} ${execution.tokenSymbol} via strategy (safe: ${safeWallet.address})`);
-
-    await this.prisma.offRampExecution.update({
-      where: { id: execution.id },
-      data: { status: 'CONVERTING' },
-    });
-
-    await this.safe.ensureDeployed(execution.userId, chainId, safeWallet.label);
-
-    const result = await strategy.execute(
-      { safe: this.safe, oneinch: this.oneinch, viem: this.viem },
-      safeWallet.id,
-      getAddress(safeWallet.address) as Address,
-      chainId,
-      amount,
-      krakenRecipient,
-    );
-
-    const outputDecimals = result.tokenSymbol === 'ETH'
-      ? 18
-      : (ENABLED_TOKENS.find((t) => t.symbol === result.tokenSymbol)?.decimals ?? 18);
-
-    const outputAmount = formatUnits(result.amount, outputDecimals);
-
-    await this.prisma.offRampExecution.update({
-      where: { id: execution.id },
-      data: {
-        conversionTxHash: result.txHash,
-        krakenTokenSymbol: result.tokenSymbol,
-        krakenTokenAmount: outputAmount,
-      },
-    });
-
-    this.logger.log(`Conversion complete: ${execution.tokenSymbol} → ${result.tokenSymbol} (${outputAmount}) tx: ${result.txHash}`);
-    this.notifyUser(execution.userId, 'Converted', `${execution.tokenAmount} ${execution.tokenSymbol} → ${outputAmount} ${result.tokenSymbol}`);
-
-    if (krakenRecipient) {
-      // Funds landed directly at Kraken — no separate Safe→Kraken transfer needed
-      await this.prisma.offRampExecution.update({
-        where: { id: execution.id },
-        data: { status: 'TRANSFERRING', onChainTxHash: result.txHash },
-      });
-      await this.enqueueNext(execution.id, DEPOSIT_POLL_DELAY_MS);
-    } else {
-      // Funds are still in the Safe — do the normal transfer step
-      const updated = await this.prisma.offRampExecution.findUnique({
-        where: { id: execution.id },
-        include: { route: { include: { safeWallet: true, bankAccount: true } } },
-      });
-      await this.handleTransfer(updated);
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Step 2 DETECTED/CONVERTING → TRANSFERRING
-  // Execute Safe → Kraken transfer (ERC-20 or native ETH)
-  // ---------------------------------------------------------------------------
-  private async handleTransfer(execution: any) {
-    const { route } = execution;
-    const { safeWallet } = route;
-
-    // Use post-conversion token if available, otherwise the originally received token
-    const krakenSymbol: string = execution.krakenTokenSymbol ?? execution.tokenSymbol;
-    const krakenAmount: string = execution.krakenTokenAmount?.toString() ?? execution.tokenAmount.toString();
-
-    await this.viem.conservativeGasFees(safeWallet.chainId);
-
-    const depositAddress = await this.resolveKrakenDepositAddress(krakenSymbol);
-
-    this.logger.log(`Transferring ${krakenAmount} ${krakenSymbol} from Safe ${safeWallet.address} to Kraken ${depositAddress}`);
-
-    // ensureDeployed is a no-op when already deployed; skipped when conversion already ran it
-    await this.safe.ensureDeployed(execution.userId, safeWallet.chainId, safeWallet.label);
-
-    await this.prisma.offRampExecution.update({
-      where: { id: execution.id },
-      data: { status: 'TRANSFERRING' },
-    });
-
-    let txHash: `0x${string}`;
-
-    if (krakenSymbol === 'ETH') {
-      // Native ETH transfer from the Safe
-      const amount = parseUnits(krakenAmount, 18);
-      txHash = await this.safe.executeRaw(
-        safeWallet.id,
-        getAddress(depositAddress) as Address,
-        '0x',
-        amount,
-      );
-    } else {
-      const tokenConfig = ENABLED_TOKENS.find((t) => t.symbol === krakenSymbol);
-      if (!tokenConfig?.addresses[safeWallet.chainId]) throw new Error(`Token ${krakenSymbol} not found in config`);
-      const tokenAddress = getAddress(tokenConfig.addresses[safeWallet.chainId]!) as Address;
-      const amount = parseUnits(krakenAmount, tokenConfig.decimals);
-      txHash = await this.safe.executeTransfer(safeWallet.id, tokenAddress, getAddress(depositAddress) as Address, amount);
-    }
-
-    await this.prisma.offRampExecution.update({
-      where: { id: execution.id },
-      data: { onChainTxHash: txHash },
-    });
-
-    await this.enqueueNext(execution.id, DEPOSIT_POLL_DELAY_MS);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Step 2 TRANSFERRING → DEPOSITED
-  // Poll Kraken until deposit confirmed
-  // ---------------------------------------------------------------------------
-  private async handleWaitDeposit(execution: any, attempt: number) {
-    if (attempt >= DEPOSIT_POLL_MAX_ATTEMPTS) {
-      throw new Error('Kraken deposit not confirmed after maximum polling attempts (2h)');
-    }
-
-    const krakenSymbol = execution.krakenTokenSymbol ?? execution.tokenSymbol;
-    const krakenAsset = KRAKEN_DEPOSIT_ASSET[krakenSymbol];
-    const statusRes = await this.krakenDeposit.getStatus(OPERATOR, { asset: krakenAsset });
-    if (statusRes.error?.length) throw new Error(`Kraken deposit status error: ${statusRes.error.join(', ')}`);
-
-    const match = statusRes.result.find(
-      (d) => d.txid === execution.onChainTxHash && d.status === 'Success',
-    );
-
-    if (!match) {
-      this.logger.log(`Execution ${execution.id}: waiting for Kraken deposit confirmation (attempt ${attempt + 1}/${DEPOSIT_POLL_MAX_ATTEMPTS})`);
-      await this.enqueueNext(execution.id, DEPOSIT_POLL_DELAY_MS, attempt + 1);
-      return;
-    }
-
-    await this.prisma.offRampExecution.update({
-      where: { id: execution.id },
-      data: { status: 'DEPOSITED', krakenDepositRef: match.refid },
-    });
-
-    this.notifyUser(execution.userId, 'Arrived at exchange', `${execution.tokenAmount} ${execution.tokenSymbol} confirmed on Kraken — swapping to fiat.`);
-
-    await this.enqueueNext(execution.id, 0);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Step 3 DEPOSITED → SOLD
-  // Place market sell order and wait for fill
-  // ---------------------------------------------------------------------------
-  private async handleSell(execution: any) {
-    const { route } = execution;
-    const krakenSymbol = execution.krakenTokenSymbol ?? execution.tokenSymbol;
-    const krakenAmount = execution.krakenTokenAmount?.toString() ?? execution.tokenAmount.toString();
-    const pair = krakenPairFor(krakenSymbol, route.targetCurrency);
-    if (!pair) throw new Error(`No Kraken trading pair for ${krakenSymbol}/${route.targetCurrency}`);
-
-    await this.prisma.offRampExecution.update({
-      where: { id: execution.id },
-      data: { status: 'SELLING' },
-    });
-
-    this.logger.log(`Placing sell order — pair: ${pair}, volume: ${krakenAmount}`);
-
-    const filledOrder = await this.krakenOrders.placeAndWait(OPERATOR, {
-      ordertype: 'market',
-      type: 'sell',
-      pair,
-      volume: krakenAmount,
-    });
-
-    const fiatAmount = filledOrder.cost;
-
-    await this.prisma.offRampExecution.update({
-      where: { id: execution.id },
-      data: {
-        status: 'SOLD',
-        krakenOrderId: filledOrder.descr.order,
-        fiatAmount,
-      },
-    });
-
-    this.notifyUser(execution.userId, 'Swapped to fiat', `${execution.tokenAmount} ${execution.tokenSymbol} → ${fiatAmount} ${route.targetCurrency} — initiating bank withdrawal.`);
-
-    await this.enqueueNext(execution.id, 0);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Step 4 SOLD → WITHDRAWING
-  // Initiate fiat withdrawal to Wrytes AG bank account
-  // ---------------------------------------------------------------------------
-  private async handleWithdraw(execution: any) {
-    const { route, fiatAmount } = execution;
-    const currency = route.targetCurrency as FiatCurrency;
-
-    const fiatAsset = KRAKEN_FIAT_ASSET[currency];
-    const withdrawKeyEnv = KRAKEN_WITHDRAW_KEY_ENV[currency];
-
-    if (!fiatAsset || !withdrawKeyEnv) {
-      throw new Error(`Currency ${currency} is not supported for fiat withdrawal`);
-    }
-
-    const withdrawKey = this.configService.get<string>(withdrawKeyEnv);
-    if (!withdrawKey) {
-      throw new Error(`${withdrawKeyEnv} is not configured — cannot initiate fiat withdrawal`);
-    }
-
-    const withdrawRes = await this.krakenWithdraw.withdraw(OPERATOR, {
-      asset: fiatAsset,
-      key: withdrawKey,
-      amount: fiatAmount.toString(),
-    });
-
-    if (withdrawRes.error?.length) throw new Error(`Kraken withdrawal error: ${withdrawRes.error.join(', ')}`);
-
-    await this.prisma.offRampExecution.update({
-      where: { id: execution.id },
-      data: { status: 'WITHDRAWING', krakenWithdrawalId: withdrawRes.result.refid },
-    });
-
-    await this.enqueueNext(execution.id, WITHDRAWAL_POLL_DELAY_MS);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Step 5 WITHDRAWING → COMPLETED
-  // Poll until withdrawal succeeds
-  // ---------------------------------------------------------------------------
-  private async handleCheckWithdrawal(execution: any, attempt: number) {
-    if (attempt >= WITHDRAWAL_POLL_MAX_ATTEMPTS) {
-      throw new Error('Fiat withdrawal not confirmed after maximum polling attempts (1h)');
-    }
-
-    const currency = execution.route.targetCurrency as FiatCurrency;
-    const fiatAsset = KRAKEN_FIAT_ASSET[currency] ?? currency;
-
-    const statusRes = await this.krakenWithdraw.withdrawStatus(OPERATOR, { asset: fiatAsset });
-    if (statusRes.error?.length) throw new Error(`Kraken withdrawal status error: ${statusRes.error.join(', ')}`);
-
-    const match = statusRes.result.find(
-      (w) => w.refid === execution.krakenWithdrawalId && w.status === 'Success',
-    );
-
-    if (!match) {
-      this.logger.log(`Execution ${execution.id}: waiting for fiat withdrawal (attempt ${attempt + 1}/${WITHDRAWAL_POLL_MAX_ATTEMPTS})`);
-      await this.enqueueNext(execution.id, WITHDRAWAL_POLL_DELAY_MS, attempt + 1);
-      return;
-    }
-
-    const route = execution.route;
-    const bankAccount = route.bankAccount;
-
-    await this.prisma.offRampExecution.update({
-      where: { id: execution.id },
-      data: { status: 'PENDING_BANK_TRANSFER' },
-    });
-
-    this.notifyUser(
-      execution.userId,
-      'Payment pending',
-      `${execution.fiatAmount} ${currency} received — your bank transfer is being prepared.`,
-    );
-
-    this.notifyAdmin(
-      'Payment pending review',
-      `Execution \`${execution.id}\`\nAmount: *${execution.fiatAmount} ${currency}*\nUser: \`${execution.userId}\`\nBank: ${bankAccount.label} — \`${bankAccount.iban}\`\n\nMark as settled: \`PATCH /offramp/executions/${execution.id}/settle\``,
-      'warning',
-    );
-
-    this.logger.log(`Execution ${execution.id} PENDING_BANK_TRANSFER — awaiting manual PostFinance transfer`);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Helpers
-  // ---------------------------------------------------------------------------
-  private async resolveKrakenDepositAddress(krakenSymbol: string): Promise<string> {
-    const krakenAsset = KRAKEN_DEPOSIT_ASSET[krakenSymbol];
-    if (!krakenAsset) {
-      throw new Error(`Token ${krakenSymbol} has no Kraken deposit mapping. Add a conversion strategy or update KRAKEN_DEPOSIT_ASSET.`);
-    }
-
-    const methodHint = KRAKEN_DEPOSIT_METHOD_HINT[krakenSymbol];
-    const methodsRes = await this.krakenDeposit.getMethods(OPERATOR, { asset: krakenAsset });
-    if (methodsRes.error?.length) throw new Error(`Kraken deposit methods error: ${methodsRes.error.join(', ')}`);
-
-    this.logger.log(`Kraken deposit methods for ${krakenAsset}: ${methodsRes.result.map((m) => m.method).join(', ')}`);
-
-    const method = methodsRes.result.find((m) => m.method.toUpperCase().includes(methodHint.toUpperCase()));
-    if (!method) throw new Error(`No deposit method found for ${krakenAsset}. Available: ${methodsRes.result.map((m) => m.method).join(', ')}`);
-
-    const addrRes = await this.krakenDeposit.getAddresses(OPERATOR, { asset: krakenAsset, method: method.method });
-    if (addrRes.error?.length) throw new Error(`Kraken deposit address error: ${addrRes.error.join(', ')}`);
-
-    const address = addrRes.result[0]?.address;
-    if (!address) throw new Error('No Kraken deposit address available');
-    return address;
-  }
-
-  private async enqueueNext(executionId: string, delayMs: number, pollAttempt = 0) {
-    await this.queue.add(
-      OFFRAMP_QUEUE,
-      { executionId, pollAttempt },
-      { delay: delayMs },
-    );
-  }
-
-  private notifyUser(userId: string, title: string, message: string, level: 'info' | 'success' | 'warning' | 'error' = 'info') {
-    this.eventEmitter.emit('notification', new NotificationEvent(userId, title, message, level));
-  }
-
-  private notifyAdmin(title: string, message: string, level: 'info' | 'success' | 'warning' | 'error' = 'info') {
-    this.eventEmitter.emit('notification.admin', new AdminNotificationEvent(title, message, level));
-  }
+	private readonly logger = new Logger(OffRampProcessor.name);
+
+	constructor(
+		private readonly prisma: PrismaService,
+		private readonly safe: SafeService,
+		private readonly viem: WalletViemService,
+		private readonly oneinch: OneInchService,
+		private readonly registry: ConversionStrategyRegistry,
+		private readonly krakenDeposit: KrakenDeposit,
+		private readonly krakenOrders: KrakenOrders,
+		private readonly krakenWithdraw: KrakenWithdraw,
+		private readonly configService: ConfigService,
+		private readonly eventEmitter: EventEmitter2,
+		@InjectQueue(OFFRAMP_QUEUE)
+		private readonly queue: Queue<OffRampJobData>,
+	) {
+		super();
+	}
+
+	async process(job: Job<OffRampJobData>): Promise<void> {
+		const { executionId } = job.data;
+
+		const execution = await this.prisma.offRampExecution.findUnique({
+			where: { id: executionId },
+			include: {
+				route: { include: { safeWallet: true, bankAccount: true } },
+			},
+		});
+
+		if (!execution) {
+			this.logger.warn(`Execution ${executionId} not found — skipping`);
+			return;
+		}
+
+		try {
+			switch (execution.status) {
+				case 'DETECTED':
+					await this.handleDetected(execution);
+					break;
+				case 'CONVERTING': {
+					const strategy = this.registry.get(execution.tokenSymbol);
+					if (execution.conversionTxHash) {
+						// Conversion already done — retry the pending transfer
+						await this.handleTransfer(execution, job.data.gasRetryAttempt ?? 0);
+					} else {
+						if (!strategy) throw new Error(`No strategy found for ${execution.tokenSymbol} in CONVERTING state`);
+						await this.handleConvert(execution, strategy, job.data.gasRetryAttempt ?? 0);
+					}
+					break;
+				}
+				case 'TRANSFERRING':
+					if (execution.onChainTxHash) {
+						await this.handleWaitDeposit(execution, job.data.pollAttempt ?? 0);
+					} else {
+						await this.handleTransfer(execution, job.data.gasRetryAttempt ?? 0);
+					}
+					break;
+				case 'DEPOSITED':
+					await this.handleSell(execution);
+					break;
+				case 'SOLD':
+					await this.handleWithdraw(execution);
+					break;
+				case 'WITHDRAWING':
+					await this.handleCheckWithdrawal(
+						execution,
+						job.data.pollAttempt ?? 0,
+					);
+					break;
+				default:
+					this.logger.warn(
+						`Execution ${executionId} in terminal status ${execution.status} — skipping`,
+					);
+			}
+		} catch (err) {
+			const error = err instanceof Error ? err.message : String(err);
+			this.logger.error(
+				`Execution ${executionId} failed at ${execution.status}: ${error}`,
+			);
+			await this.prisma.offRampExecution.update({
+				where: { id: executionId },
+				data: { status: 'FAILED', error },
+			});
+			this.notifyUser(
+				execution.userId,
+				'Off-ramp failed',
+				`Your off-ramp could not be completed: ${error}`,
+				'error',
+			);
+			this.notifyAdmin(
+				'Off-ramp execution failed',
+				`Execution \`${executionId}\` failed at status \`${execution.status}\`\n\nError: ${error}`,
+				'error',
+			);
+		}
+	}
+
+	// ---------------------------------------------------------------------------
+	// Step 1a DETECTED — route to conversion or direct transfer
+	// ---------------------------------------------------------------------------
+	private async handleDetected(execution: any) {
+		this.notifyUser(
+			execution.userId,
+			'Received',
+			`${execution.tokenAmount} ${execution.tokenSymbol} received.`,
+		);
+		const strategy = this.registry.get(execution.tokenSymbol);
+		if (strategy) {
+			await this.prisma.offRampExecution.update({ where: { id: execution.id }, data: { status: 'CONVERTING' } });
+			await this.handleConvert(execution, strategy, 0);
+		} else {
+			await this.prisma.offRampExecution.update({ where: { id: execution.id }, data: { status: 'TRANSFERRING' } });
+			await this.handleTransfer(execution, 0);
+		}
+	}
+
+	// ---------------------------------------------------------------------------
+	// Step 1b CONVERTING — run pre-deposit conversion strategy (unwrap, swap, redeem, …)
+	// ---------------------------------------------------------------------------
+	private async handleConvert(execution: any, strategy: any, gasRetryAttempt: number) {
+		const { route } = execution;
+		const { safeWallet } = route;
+		const chainId = safeWallet.chainId;
+
+		const tokenConfig = ENABLED_TOKENS.find(
+			(t) => t.symbol === execution.tokenSymbol,
+		);
+		if (!tokenConfig)
+			throw new Error(
+				`Token ${execution.tokenSymbol} not found in config`,
+			);
+
+		const amount = parseUnits(
+			execution.tokenAmount.toString(),
+			tokenConfig.decimals,
+		);
+
+		try {
+			await this.viem.conservativeGasFees(chainId);
+
+			// If the strategy outputs a Kraken-mapped token, route the swap directly to the Kraken
+			// deposit address — this saves one on-chain transfer from the Safe.
+			let krakenRecipient: Address | undefined;
+			if (strategy.outputSymbol && KRAKEN_DEPOSIT_ASSET[strategy.outputSymbol]) {
+				const depositAddress = await this.resolveKrakenDepositAddress(strategy.outputSymbol);
+				krakenRecipient = getAddress(depositAddress) as Address;
+				this.logger.log(`Routing ${strategy.outputSymbol} swap output directly to Kraken deposit address ${depositAddress}`);
+			}
+
+			this.logger.log(`Converting ${execution.tokenAmount} ${execution.tokenSymbol} via strategy (safe: ${safeWallet.address})`);
+
+			await this.safe.ensureDeployed(execution.userId, chainId, safeWallet.label);
+
+			const result = await strategy.execute(
+				{ safe: this.safe, oneinch: this.oneinch, viem: this.viem },
+				safeWallet.id,
+				getAddress(safeWallet.address) as Address,
+				chainId,
+				amount,
+				krakenRecipient,
+			);
+
+			const outputDecimals =
+				result.tokenSymbol === 'ETH'
+					? 18
+					: (ENABLED_TOKENS.find((t) => t.symbol === result.tokenSymbol)?.decimals ?? 18);
+			const outputAmount = formatUnits(result.amount, outputDecimals);
+
+			await this.prisma.offRampExecution.update({
+				where: { id: execution.id },
+				data: {
+					conversionTxHash: result.txHash,
+					krakenTokenSymbol: result.tokenSymbol,
+					krakenTokenAmount: outputAmount,
+				},
+			});
+
+			this.logger.log(`Conversion complete: ${execution.tokenSymbol} → ${result.tokenSymbol} (${outputAmount}) tx: ${result.txHash}`);
+			this.notifyUser(execution.userId, 'Converted', `${execution.tokenAmount} ${execution.tokenSymbol} → ${outputAmount} ${result.tokenSymbol}`);
+
+			if (krakenRecipient) {
+				// Funds landed directly at Kraken — no separate Safe→Kraken transfer needed
+				await this.prisma.offRampExecution.update({
+					where: { id: execution.id },
+					data: { status: 'TRANSFERRING', onChainTxHash: result.txHash },
+				});
+				await this.enqueueNext(execution.id, DEPOSIT_POLL_DELAY_MS);
+			} else {
+				// Funds are still in the Safe — proceed to transfer (status stays CONVERTING until handleTransfer sets TRANSFERRING)
+				const updated = await this.prisma.offRampExecution.findUnique({
+					where: { id: execution.id },
+					include: { route: { include: { safeWallet: true, bankAccount: true } } },
+				});
+				await this.handleTransfer(updated, gasRetryAttempt);
+			}
+		} catch (err) {
+			if (err instanceof GasTooHighError) {
+				await this.retryOnGas(execution.id, gasRetryAttempt, err.message);
+				return;
+			}
+			throw err;
+		}
+	}
+
+	// ---------------------------------------------------------------------------
+	// Step 2 TRANSFERRING — execute Safe → Kraken transfer (ERC-20 or native ETH)
+	// ---------------------------------------------------------------------------
+	private async handleTransfer(execution: any, gasRetryAttempt: number) {
+		const { route } = execution;
+		const { safeWallet } = route;
+
+		// Use post-conversion token if available, otherwise the originally received token
+		const krakenSymbol: string = execution.krakenTokenSymbol ?? execution.tokenSymbol;
+		const krakenAmount: string = execution.krakenTokenAmount?.toString() ?? execution.tokenAmount.toString();
+
+		try {
+			await this.viem.conservativeGasFees(safeWallet.chainId);
+
+			const depositAddress = await this.resolveKrakenDepositAddress(krakenSymbol);
+
+			this.logger.log(`Transferring ${krakenAmount} ${krakenSymbol} from Safe ${safeWallet.address} to Kraken ${depositAddress}`);
+
+			// ensureDeployed is a no-op when already deployed; skipped when conversion already ran it
+			await this.safe.ensureDeployed(execution.userId, safeWallet.chainId, safeWallet.label);
+
+			await this.prisma.offRampExecution.update({
+				where: { id: execution.id },
+				data: { status: 'TRANSFERRING' },
+			});
+
+			let txHash: `0x${string}`;
+
+			if (krakenSymbol === 'ETH') {
+				const amount = parseUnits(krakenAmount, 18);
+				txHash = await this.safe.executeRaw(safeWallet.id, getAddress(depositAddress) as Address, '0x', amount);
+			} else {
+				const tokenConfig = ENABLED_TOKENS.find((t) => t.symbol === krakenSymbol);
+				if (!tokenConfig?.addresses[safeWallet.chainId])
+					throw new Error(`Token ${krakenSymbol} not found in config`);
+				const tokenAddress = getAddress(tokenConfig.addresses[safeWallet.chainId]!) as Address;
+				const amount = parseUnits(krakenAmount, tokenConfig.decimals);
+				txHash = await this.safe.executeTransfer(safeWallet.id, tokenAddress, getAddress(depositAddress) as Address, amount);
+			}
+
+			await this.prisma.offRampExecution.update({
+				where: { id: execution.id },
+				data: { onChainTxHash: txHash },
+			});
+
+			await this.enqueueNext(execution.id, DEPOSIT_POLL_DELAY_MS);
+		} catch (err) {
+			if (err instanceof GasTooHighError) {
+				await this.retryOnGas(execution.id, gasRetryAttempt, err.message);
+				return;
+			}
+			throw err;
+		}
+	}
+
+	// ---------------------------------------------------------------------------
+	// Step 2 TRANSFERRING → DEPOSITED
+	// Poll Kraken until deposit confirmed
+	// ---------------------------------------------------------------------------
+	private async handleWaitDeposit(execution: any, attempt: number) {
+		if (attempt >= DEPOSIT_POLL_MAX_ATTEMPTS) {
+			throw new Error(
+				'Kraken deposit not confirmed after maximum polling attempts (2h)',
+			);
+		}
+
+		const krakenSymbol =
+			execution.krakenTokenSymbol ?? execution.tokenSymbol;
+		const krakenAsset = KRAKEN_DEPOSIT_ASSET[krakenSymbol];
+		const statusRes = await this.krakenDeposit.getStatus(OPERATOR, {
+			asset: krakenAsset,
+		});
+		if (statusRes.error?.length)
+			throw new Error(
+				`Kraken deposit status error: ${statusRes.error.join(', ')}`,
+			);
+
+		const match = statusRes.result.find(
+			(d) => d.txid === execution.onChainTxHash && d.status === 'Success',
+		);
+
+		if (!match) {
+			this.logger.log(
+				`Execution ${execution.id}: waiting for Kraken deposit confirmation (attempt ${attempt + 1}/${DEPOSIT_POLL_MAX_ATTEMPTS})`,
+			);
+			await this.enqueueNext(
+				execution.id,
+				DEPOSIT_POLL_DELAY_MS,
+				attempt + 1,
+			);
+			return;
+		}
+
+		await this.prisma.offRampExecution.update({
+			where: { id: execution.id },
+			data: { status: 'DEPOSITED', krakenDepositRef: match.refid },
+		});
+
+		this.notifyUser(
+			execution.userId,
+			'Arrived at exchange',
+			`${execution.tokenAmount} ${execution.tokenSymbol} confirmed on Kraken — swapping to fiat.`,
+		);
+
+		await this.enqueueNext(execution.id, 0);
+	}
+
+	// ---------------------------------------------------------------------------
+	// Step 3 DEPOSITED → SOLD
+	// Place market sell order and wait for fill
+	// ---------------------------------------------------------------------------
+	private async handleSell(execution: any) {
+		const { route } = execution;
+		const krakenSymbol =
+			execution.krakenTokenSymbol ?? execution.tokenSymbol;
+		const krakenAmount =
+			execution.krakenTokenAmount?.toString() ??
+			execution.tokenAmount.toString();
+		const pair = krakenPairFor(krakenSymbol, route.targetCurrency);
+		if (!pair)
+			throw new Error(
+				`No Kraken trading pair for ${krakenSymbol}/${route.targetCurrency}`,
+			);
+
+		await this.prisma.offRampExecution.update({
+			where: { id: execution.id },
+			data: { status: 'SELLING' },
+		});
+
+		this.logger.log(
+			`Placing sell order — pair: ${pair}, volume: ${krakenAmount}`,
+		);
+
+		const filledOrder = await this.krakenOrders.placeAndWait(OPERATOR, {
+			ordertype: 'market',
+			type: 'sell',
+			pair,
+			volume: krakenAmount,
+		});
+
+		const fiatAmount = filledOrder.cost;
+
+		await this.prisma.offRampExecution.update({
+			where: { id: execution.id },
+			data: {
+				status: 'SOLD',
+				krakenOrderId: filledOrder.descr.order,
+				fiatAmount,
+			},
+		});
+
+		this.notifyUser(
+			execution.userId,
+			'Swapped to fiat',
+			`${execution.tokenAmount} ${execution.tokenSymbol} → ${fiatAmount} ${route.targetCurrency} — initiating bank withdrawal.`,
+		);
+
+		await this.enqueueNext(execution.id, 0);
+	}
+
+	// ---------------------------------------------------------------------------
+	// Step 4 SOLD → WITHDRAWING
+	// Initiate fiat withdrawal to Wrytes AG bank account
+	// ---------------------------------------------------------------------------
+	private async handleWithdraw(execution: any) {
+		const { route, fiatAmount } = execution;
+		const currency = route.targetCurrency as FiatCurrency;
+
+		const fiatAsset = KRAKEN_FIAT_ASSET[currency];
+		const withdrawKeyEnv = KRAKEN_WITHDRAW_KEY_ENV[currency];
+
+		if (!fiatAsset || !withdrawKeyEnv) {
+			throw new Error(
+				`Currency ${currency} is not supported for fiat withdrawal`,
+			);
+		}
+
+		const withdrawKey = this.configService.get<string>(withdrawKeyEnv);
+		if (!withdrawKey) {
+			throw new Error(
+				`${withdrawKeyEnv} is not configured — cannot initiate fiat withdrawal`,
+			);
+		}
+
+		const withdrawRes = await this.krakenWithdraw.withdraw(OPERATOR, {
+			asset: fiatAsset,
+			key: withdrawKey,
+			amount: fiatAmount.toString(),
+		});
+
+		if (withdrawRes.error?.length)
+			throw new Error(
+				`Kraken withdrawal error: ${withdrawRes.error.join(', ')}`,
+			);
+
+		await this.prisma.offRampExecution.update({
+			where: { id: execution.id },
+			data: {
+				status: 'WITHDRAWING',
+				krakenWithdrawalId: withdrawRes.result.refid,
+			},
+		});
+
+		await this.enqueueNext(execution.id, WITHDRAWAL_POLL_DELAY_MS);
+	}
+
+	// ---------------------------------------------------------------------------
+	// Step 5 WITHDRAWING → COMPLETED
+	// Poll until withdrawal succeeds
+	// ---------------------------------------------------------------------------
+	private async handleCheckWithdrawal(execution: any, attempt: number) {
+		if (attempt >= WITHDRAWAL_POLL_MAX_ATTEMPTS) {
+			throw new Error(
+				'Fiat withdrawal not confirmed after maximum polling attempts (1h)',
+			);
+		}
+
+		const currency = execution.route.targetCurrency as FiatCurrency;
+		const fiatAsset = KRAKEN_FIAT_ASSET[currency] ?? currency;
+
+		const statusRes = await this.krakenWithdraw.withdrawStatus(OPERATOR, {
+			asset: fiatAsset,
+		});
+		if (statusRes.error?.length)
+			throw new Error(
+				`Kraken withdrawal status error: ${statusRes.error.join(', ')}`,
+			);
+
+		const match = statusRes.result.find(
+			(w) =>
+				w.refid === execution.krakenWithdrawalId &&
+				w.status === 'Success',
+		);
+
+		if (!match) {
+			this.logger.log(
+				`Execution ${execution.id}: waiting for fiat withdrawal (attempt ${attempt + 1}/${WITHDRAWAL_POLL_MAX_ATTEMPTS})`,
+			);
+			await this.enqueueNext(
+				execution.id,
+				WITHDRAWAL_POLL_DELAY_MS,
+				attempt + 1,
+			);
+			return;
+		}
+
+		const route = execution.route;
+		const bankAccount = route.bankAccount;
+
+		await this.prisma.offRampExecution.update({
+			where: { id: execution.id },
+			data: { status: 'PENDING_BANK_TRANSFER' },
+		});
+
+		this.notifyUser(
+			execution.userId,
+			'Payment pending',
+			`${execution.fiatAmount} ${currency} received — your bank transfer is being prepared.`,
+		);
+
+		this.notifyAdmin(
+			'Payment pending review',
+			`Execution \`${execution.id}\`\nAmount: *${execution.fiatAmount} ${currency}*\nUser: \`${execution.userId}\`\nBank: ${bankAccount.label} — \`${bankAccount.iban}\`\n\nMark as settled: \`PATCH /offramp/executions/${execution.id}/settle\``,
+			'warning',
+		);
+
+		this.logger.log(
+			`Execution ${execution.id} PENDING_BANK_TRANSFER — awaiting manual PostFinance transfer`,
+		);
+	}
+
+	// ---------------------------------------------------------------------------
+	// Helpers
+	// ---------------------------------------------------------------------------
+	private async retryOnGas(executionId: string, attempt: number, message: string) {
+		const next = attempt + 1;
+		if (next > GAS_RETRY_MAX_ATTEMPTS) {
+			this.logger.error(`Execution ${executionId}: gas remained too high after 5 days — failing`);
+			throw new Error(`Gas too high after ${GAS_RETRY_MAX_ATTEMPTS} attempts: ${message}`);
+		}
+		this.logger.warn(`Execution ${executionId}: ${message} (attempt ${next}/${GAS_RETRY_MAX_ATTEMPTS})`);
+		await this.queue.add(OFFRAMP_QUEUE, { executionId, gasRetryAttempt: next }, { delay: GAS_RETRY_DELAY_MS });
+	}
+
+	private async resolveKrakenDepositAddress(
+		krakenSymbol: string,
+	): Promise<string> {
+		const krakenAsset = KRAKEN_DEPOSIT_ASSET[krakenSymbol];
+		if (!krakenAsset) {
+			throw new Error(
+				`Token ${krakenSymbol} has no Kraken deposit mapping. Add a conversion strategy or update KRAKEN_DEPOSIT_ASSET.`,
+			);
+		}
+
+		const methodHint = KRAKEN_DEPOSIT_METHOD_HINT[krakenSymbol];
+		const methodsRes = await this.krakenDeposit.getMethods(OPERATOR, {
+			asset: krakenAsset,
+		});
+		if (methodsRes.error?.length)
+			throw new Error(
+				`Kraken deposit methods error: ${methodsRes.error.join(', ')}`,
+			);
+
+		this.logger.log(
+			`Kraken deposit methods for ${krakenAsset}: ${methodsRes.result.map((m) => m.method).join(', ')}`,
+		);
+
+		const method = methodsRes.result.find((m) =>
+			m.method.toUpperCase().includes(methodHint.toUpperCase()),
+		);
+		if (!method)
+			throw new Error(
+				`No deposit method found for ${krakenAsset}. Available: ${methodsRes.result.map((m) => m.method).join(', ')}`,
+			);
+
+		const addrRes = await this.krakenDeposit.getAddresses(OPERATOR, {
+			asset: krakenAsset,
+			method: method.method,
+		});
+		if (addrRes.error?.length)
+			throw new Error(
+				`Kraken deposit address error: ${addrRes.error.join(', ')}`,
+			);
+
+		const address = addrRes.result[0]?.address;
+		if (!address) throw new Error('No Kraken deposit address available');
+		return address;
+	}
+
+	private async enqueueNext(
+		executionId: string,
+		delayMs: number,
+		pollAttempt = 0,
+	) {
+		await this.queue.add(
+			OFFRAMP_QUEUE,
+			{ executionId, pollAttempt },
+			{ delay: delayMs },
+		);
+	}
+
+	private notifyUser(
+		userId: string,
+		title: string,
+		message: string,
+		level: 'info' | 'success' | 'warning' | 'error' = 'info',
+	) {
+		this.eventEmitter.emit(
+			'notification',
+			new NotificationEvent(userId, title, message, level),
+		);
+	}
+
+	private notifyAdmin(
+		title: string,
+		message: string,
+		level: 'info' | 'success' | 'warning' | 'error' = 'info',
+	) {
+		this.eventEmitter.emit(
+			'notification.admin',
+			new AdminNotificationEvent(title, message, level),
+		);
+	}
 }

--- a/src/core/offramp/offramp.queue.ts
+++ b/src/core/offramp/offramp.queue.ts
@@ -6,6 +6,8 @@ export interface OffRampJobData {
   executionId: string;
   /** Incremented on each polling re-enqueue; used to enforce max wait time without BullMQ retries */
   pollAttempt?: number;
+  /** Incremented each time a step is skipped due to high gas; execution resumes when gas drops */
+  gasRetryAttempt?: number;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/offramp/strategies/conversion.types.ts
+++ b/src/core/offramp/strategies/conversion.types.ts
@@ -22,11 +22,15 @@ export interface ConversionResult {
 }
 
 export interface ConversionStrategy {
+  /** Output token symbol; present when the strategy supports routing output to a custom recipient. */
+  outputSymbol?: string;
+
   execute(
     ctx: ConversionContext,
     safeWalletId: string,
     safeAddress: Address,
     chainId: ChainId,
     amount: bigint,
+    recipient?: Address,
   ): Promise<ConversionResult>;
 }

--- a/src/core/offramp/strategies/swap-oneinch.strategy.ts
+++ b/src/core/offramp/strategies/swap-oneinch.strategy.ts
@@ -9,11 +9,15 @@ import { ENABLED_TOKENS } from '../../../config/tokens.config';
  * Handles approve if the Safe's allowance is insufficient.
  */
 export class SwapOneInchStrategy implements ConversionStrategy {
+  readonly outputSymbol: string;
+
   constructor(
     private readonly srcSymbol: string,
     private readonly dstSymbol: string,
     private readonly slippage = 0.5,
-  ) {}
+  ) {
+    this.outputSymbol = dstSymbol;
+  }
 
   async execute(
     ctx: ConversionContext,
@@ -21,6 +25,7 @@ export class SwapOneInchStrategy implements ConversionStrategy {
     safeAddress: Address,
     chainId: ChainId,
     amount: bigint,
+    recipient?: Address,
   ): Promise<ConversionResult> {
     const srcToken = ENABLED_TOKENS.find((t) => t.symbol === this.srcSymbol);
     const dstToken = ENABLED_TOKENS.find((t) => t.symbol === this.dstSymbol);
@@ -35,6 +40,7 @@ export class SwapOneInchStrategy implements ConversionStrategy {
     const swap = await ctx.oneinch.swap(chainId, srcAddress, dstAddress, amount, safeAddress, {
       slippage: this.slippage,
       disableEstimate: true,
+      ...(recipient ? { receiver: recipient } : {}),
     });
 
     const allowance = await ctx.oneinch.allowance(chainId, srcAddress, safeAddress);

--- a/src/integrations/safe/safe.service.ts
+++ b/src/integrations/safe/safe.service.ts
@@ -103,12 +103,14 @@ export class SafeService {
 		this.logger.log(`Deploying Safe ${safeWallet.address} for user ${userId} on chain ${chainId}`);
 
 		const deployTx = await sdk.createSafeDeploymentTransaction();
+		const gasFees = await this.viemService.conservativeGasFees(chainId);
 		const hash = await this.wallet.client[chainId].sendTransaction({
 			account: this.wallet.account,
 			chain: null,
 			to: deployTx.to as `0x${string}`,
 			data: deployTx.data as `0x${string}`,
 			value: BigInt(deployTx.value ?? 0),
+			...gasFees,
 		});
 
 		await this.viemService.getClient(chainId).waitForTransactionReceipt({ hash });
@@ -166,7 +168,11 @@ export class SafeService {
 		});
 
 		const signedTx = await sdk.signTransaction(safeTx);
-		const result = await sdk.executeTransaction(signedTx);
+		const gasFees = await this.viemService.conservativeGasFees(chainId);
+		const result = await sdk.executeTransaction(signedTx, {
+			maxFeePerGas: gasFees.maxFeePerGas.toString(),
+			maxPriorityFeePerGas: gasFees.maxPriorityFeePerGas.toString(),
+		});
 		const txHash = result.hash as `0x${string}`;
 
 		this.logger.log(`Safe batch tx executed — safe: ${safeWallet.address}, ops: ${txs.length}, tx: ${txHash}`);
@@ -204,7 +210,11 @@ export class SafeService {
 		});
 
 		const signedTx = await sdk.signTransaction(safeTx);
-		const result = await sdk.executeTransaction(signedTx);
+		const gasFees = await this.viemService.conservativeGasFees(chainId);
+		const result = await sdk.executeTransaction(signedTx, {
+			maxFeePerGas: gasFees.maxFeePerGas.toString(),
+			maxPriorityFeePerGas: gasFees.maxPriorityFeePerGas.toString(),
+		});
 		const txHash = result.hash as `0x${string}`;
 
 		this.logger.log(`Safe transfer executed — safe: ${safeWallet.address}, token: ${tokenAddress}, to: ${toAddress}, tx: ${txHash}`);

--- a/src/integrations/wallet/wallet.viem.service.ts
+++ b/src/integrations/wallet/wallet.viem.service.ts
@@ -1,39 +1,76 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { createPublicClient, http } from 'viem';
+import { createPublicClient, http, parseGwei, formatGwei } from 'viem';
 import { mainnet } from 'viem/chains';
 import { ChainId, ALCHEMY_CHAIN_SLUGS } from './wallet.types';
 
+// Conservative gas cap: tip never exceeds this value; maxFeePerGas = baseFee × 1.5 + tip
+const MAX_PRIORITY_FEE_PER_GAS = parseGwei('0.2');
+// Hard base fee ceiling — conservativeGasFees() throws GasTooHighError above this
+const MAX_BASE_FEE = parseGwei('0.3');
+
+export class GasTooHighError extends Error {
+	constructor(baseFee: bigint) {
+		super(
+			`Base fee ${formatGwei(baseFee)} gwei exceeds limit of ${formatGwei(MAX_BASE_FEE)} gwei — will retry later`,
+		);
+		this.name = 'GasTooHighError';
+	}
+}
+
 type ViemPublicClient = ReturnType<typeof createPublicClient>;
 
-const CHAIN_DEFINITIONS: { chainId: ChainId; chain: Parameters<typeof createPublicClient>[0]['chain'] }[] = [
-  { chainId: 1, chain: mainnet },
-  // extend: { chainId: 100, chain: gnosis }, { chainId: 8453, chain: base }, { chainId: 42161, chain: arbitrum }
+const CHAIN_DEFINITIONS: {
+	chainId: ChainId;
+	chain: Parameters<typeof createPublicClient>[0]['chain'];
+}[] = [
+	{ chainId: 1, chain: mainnet },
+	// extend: { chainId: 100, chain: gnosis }, { chainId: 8453, chain: base }, { chainId: 42161, chain: arbitrum }
 ];
 
 @Injectable()
 export class WalletViemService {
-  private readonly clients = new Map<ChainId, ViemPublicClient>();
+	private readonly clients = new Map<ChainId, ViemPublicClient>();
 
-  constructor(private readonly configService: ConfigService) {
-    const apiKey = this.configService.get<string>('alchemy.apiKey', '');
+	constructor(private readonly configService: ConfigService) {
+		const apiKey = this.configService.get<string>('alchemy.apiKey', '');
 
-    for (const { chainId, chain } of CHAIN_DEFINITIONS) {
-      const slug = ALCHEMY_CHAIN_SLUGS[chainId];
-      this.clients.set(
-        chainId,
-        createPublicClient({
-          chain,
-          transport: http(`https://${slug}.g.alchemy.com/v2/${apiKey}`),
-          batch: { multicall: { wait: 200 } },
-        }),
-      );
-    }
-  }
+		for (const { chainId, chain } of CHAIN_DEFINITIONS) {
+			const slug = ALCHEMY_CHAIN_SLUGS[chainId];
+			this.clients.set(
+				chainId,
+				createPublicClient({
+					chain,
+					transport: http(
+						`https://${slug}.g.alchemy.com/v2/${apiKey}`,
+					),
+					batch: { multicall: { wait: 200 } },
+				}),
+			);
+		}
+	}
 
-  getClient(chainId: ChainId): ViemPublicClient {
-    const client = this.clients.get(chainId);
-    if (!client) throw new Error(`No public client configured for chain ${chainId}`);
-    return client;
-  }
+	getClient(chainId: ChainId): ViemPublicClient {
+		const client = this.clients.get(chainId);
+		if (!client)
+			throw new Error(`No public client configured for chain ${chainId}`);
+		return client;
+	}
+
+	async conservativeGasFees(
+		chainId: ChainId,
+	): Promise<{ maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }> {
+		const block = await this.getClient(chainId).getBlock({
+			blockTag: 'latest',
+		});
+		if (!block.baseFeePerGas)
+			throw new Error(`Chain ${chainId} does not support EIP-1559`);
+		if (block.baseFeePerGas > MAX_BASE_FEE)
+			throw new GasTooHighError(block.baseFeePerGas);
+		return {
+			maxPriorityFeePerGas: MAX_PRIORITY_FEE_PER_GAS,
+			maxFeePerGas:
+				(block.baseFeePerGas * 3n) / 2n + MAX_PRIORITY_FEE_PER_GAS,
+		};
+	}
 }

--- a/src/modules/accounting/accounting.controller.ts
+++ b/src/modules/accounting/accounting.controller.ts
@@ -1,0 +1,314 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  Query,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiSecurity, ApiParam, ApiBody, ApiQuery } from '@nestjs/swagger';
+import { TransferClassification, AccountType, NormalBalance } from '@prisma/client';
+import { AccountingService } from './accounting.service';
+import { ScopesGuard } from '../../common/guards/scopes.guard';
+import { RequireScopes } from '../../common/decorators/require-scopes.decorator';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import type { User } from '@prisma/client';
+
+@ApiTags('Accounting')
+@ApiSecurity('api-key')
+@UseGuards(ScopesGuard)
+@RequireScopes('USER')
+@Controller('accounting')
+export class AccountingController {
+  constructor(private readonly service: AccountingService) {}
+
+  // ---------------------------------------------------------------------------
+  // Addresses
+  // ---------------------------------------------------------------------------
+
+  @Post('addresses')
+  @ApiOperation({ summary: 'Add a wallet address to track' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['address', 'chain'],
+      properties: {
+        address: { type: 'string', example: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045' },
+        chain: { type: 'string', example: 'eth-mainnet', description: 'Alchemy chain slug' },
+        label: { type: 'string', example: 'Treasury' },
+      },
+    },
+  })
+  addAddress(
+    @CurrentUser() user: User,
+    @Body() body: { address: string; chain: string; label?: string },
+  ) {
+    return this.service.addAddress(user.id, body.address, body.chain, body.label);
+  }
+
+  @Get('addresses')
+  @ApiOperation({ summary: 'List tracked wallet addresses' })
+  listAddresses(@CurrentUser() user: User) {
+    return this.service.listAddresses(user.id);
+  }
+
+  @Delete('addresses/:id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Remove a tracked address and its transfers' })
+  @ApiParam({ name: 'id' })
+  removeAddress(@CurrentUser() user: User, @Param('id') id: string) {
+    return this.service.removeAddress(user.id, id);
+  }
+
+  @Post('addresses/:id/sync')
+  @ApiOperation({ summary: 'Sync all token transfers from Alchemy for this address' })
+  @ApiParam({ name: 'id' })
+  syncAddress(@CurrentUser() user: User, @Param('id') id: string) {
+    return this.service.syncAddress(user.id, id);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Transfers
+  // ---------------------------------------------------------------------------
+
+  @Get('addresses/:id/transfers')
+  @ApiOperation({ summary: 'List transfers for a tracked address' })
+  @ApiParam({ name: 'id' })
+  @ApiQuery({ name: 'search', required: false })
+  @ApiQuery({ name: 'classification', required: false, enum: TransferClassification })
+  @ApiQuery({ name: 'direction', required: false, enum: ['IN', 'OUT'] })
+  @ApiQuery({ name: 'showHidden', required: false, type: Boolean })
+  @ApiQuery({ name: 'skip', required: false, type: Number })
+  @ApiQuery({ name: 'take', required: false, type: Number })
+  @ApiQuery({ name: 'sortBy', required: false })
+  @ApiQuery({ name: 'sortDir', required: false, enum: ['asc', 'desc'] })
+  getTransfers(
+    @CurrentUser() user: User,
+    @Param('id') id: string,
+    @Query('search') search?: string,
+    @Query('classification') classification?: string,
+    @Query('direction') direction?: string,
+    @Query('showHidden') showHidden?: string,
+    @Query('skip') skip?: string,
+    @Query('take') take?: string,
+    @Query('sortBy') sortBy?: string,
+    @Query('sortDir') sortDir?: string,
+  ) {
+    return this.service.getTransfers(user.id, id, {
+      search,
+      classification,
+      direction,
+      showHidden: showHidden === 'true',
+      skip: skip ? parseInt(skip, 10) : 0,
+      take: take ? parseInt(take, 10) : 50,
+      sortBy,
+      sortDir: (sortDir as 'asc' | 'desc') ?? 'desc',
+    });
+  }
+
+  @Get('addresses/:id/summary')
+  @ApiOperation({ summary: 'Accounting summary grouped by token (assets/liabilities)' })
+  @ApiParam({ name: 'id' })
+  getSummary(@CurrentUser() user: User, @Param('id') id: string) {
+    return this.service.getSummary(user.id, id);
+  }
+
+  @Get('addresses/:id/token-balances')
+  @ApiOperation({ summary: 'Per-token IN/OUT balance breakdown for a tracked address' })
+  @ApiParam({ name: 'id' })
+  getTokenBalances(@CurrentUser() user: User, @Param('id') id: string) {
+    return this.service.getTokenBalances(user.id, id);
+  }
+
+  @Patch('transfers/:id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Update classification, hidden flag, or notes on a transfer' })
+  @ApiParam({ name: 'id' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        classification: { type: 'string', enum: Object.values(TransferClassification) },
+        isHidden: { type: 'boolean' },
+        chfValue: { type: 'string', nullable: true },
+        notes: { type: 'string', nullable: true },
+      },
+    },
+  })
+  updateTransfer(
+    @CurrentUser() user: User,
+    @Param('id') id: string,
+    @Body() body: { classification?: TransferClassification; isHidden?: boolean; chfValue?: string | null; notes?: string | null },
+  ) {
+    return this.service.updateTransfer(user.id, id, body);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Blacklist
+  // ---------------------------------------------------------------------------
+
+  @Get('blacklist')
+  @ApiOperation({ summary: 'List globally blacklisted tokens (scam/spam)' })
+  getBlacklist() {
+    return this.service.getBlacklist();
+  }
+
+  @Post('blacklist')
+  @ApiOperation({ summary: 'Add a token to the global blacklist' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['tokenAddress', 'chainId'],
+      properties: {
+        tokenAddress: { type: 'string' },
+        chainId: { type: 'number' },
+        tokenSymbol: { type: 'string' },
+        reason: { type: 'string' },
+      },
+    },
+  })
+  addToBlacklist(
+    @CurrentUser() user: User,
+    @Body() body: { tokenAddress: string; chainId: number; tokenSymbol?: string; reason?: string },
+  ) {
+    return this.service.addToBlacklist(user.id, body.tokenAddress, body.chainId, body.tokenSymbol, body.reason);
+  }
+
+  @Delete('blacklist/:id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Remove a token from the blacklist' })
+  @ApiParam({ name: 'id' })
+  removeFromBlacklist(@Param('id') id: string) {
+    return this.service.removeFromBlacklist(id);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Chart of accounts
+  // ---------------------------------------------------------------------------
+
+  @Get('accounts')
+  @ApiOperation({ summary: 'List chart of accounts for the current user' })
+  getAccounts(@CurrentUser() user: User) {
+    return this.service.getAccounts(user.id);
+  }
+
+  @Post('accounts')
+  @ApiOperation({ summary: 'Create a new account' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['name', 'type', 'normalBalance'],
+      properties: {
+        name:          { type: 'string' },
+        code:          { type: 'string' },
+        type:          { type: 'string', enum: Object.values(AccountType) },
+        normalBalance: { type: 'string', enum: Object.values(NormalBalance) },
+        description:   { type: 'string' },
+      },
+    },
+  })
+  createAccount(
+    @CurrentUser() user: User,
+    @Body() body: { name: string; code?: string; type: AccountType; normalBalance: NormalBalance; description?: string },
+  ) {
+    return this.service.createAccount(user.id, body);
+  }
+
+  @Patch('accounts/:id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Update account name, code, or description' })
+  @ApiParam({ name: 'id' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        name:        { type: 'string' },
+        code:        { type: 'string' },
+        description: { type: 'string' },
+      },
+    },
+  })
+  updateAccount(
+    @CurrentUser() user: User,
+    @Param('id') id: string,
+    @Body() body: { name?: string; code?: string; description?: string },
+  ) {
+    return this.service.updateAccount(user.id, id, body);
+  }
+
+  @Delete('accounts/:id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Delete an account (only if no journal lines reference it)' })
+  @ApiParam({ name: 'id' })
+  deleteAccount(@CurrentUser() user: User, @Param('id') id: string) {
+    return this.service.deleteAccount(user.id, id);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Classification templates
+  // ---------------------------------------------------------------------------
+
+  @Get('templates')
+  @ApiOperation({ summary: 'List all classification templates (defaults + user overrides)' })
+  getTemplates(@CurrentUser() user: User) {
+    return this.service.getTemplates(user.id);
+  }
+
+  @Put('templates')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Upsert a classification template override' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['classification', 'direction', 'debitAccountId', 'creditAccountId'],
+      properties: {
+        classification:  { type: 'string', enum: Object.values(TransferClassification) },
+        direction:       { type: 'string', enum: ['IN', 'OUT', 'ANY'] },
+        debitAccountId:  { type: 'string' },
+        creditAccountId: { type: 'string' },
+      },
+    },
+  })
+  upsertTemplate(
+    @CurrentUser() user: User,
+    @Body() body: { classification: TransferClassification; direction: string; debitAccountId: string; creditAccountId: string },
+  ) {
+    return this.service.upsertTemplate(user.id, body);
+  }
+
+  @Delete('templates/:id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Remove a template override (reverts to default)' })
+  @ApiParam({ name: 'id' })
+  deleteTemplate(@CurrentUser() user: User, @Param('id') id: string) {
+    return this.service.deleteTemplate(user.id, id);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Trial balance
+  // ---------------------------------------------------------------------------
+
+  @Get('trial-balance')
+  @ApiOperation({ summary: 'Trial balance across all addresses' })
+  @ApiQuery({ name: 'addressId', required: false })
+  getTrialBalance(@CurrentUser() user: User, @Query('addressId') addressId?: string) {
+    return this.service.getTrialBalance(user.id, addressId);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Journal entries
+  // ---------------------------------------------------------------------------
+
+  @Get('addresses/:id/journal')
+  @ApiOperation({ summary: 'Journal entries for a tracked address' })
+  @ApiParam({ name: 'id' })
+  getJournalEntries(@CurrentUser() user: User, @Param('id') id: string) {
+    return this.service.getJournalEntries(user.id, id);
+  }
+}

--- a/src/modules/accounting/accounting.controller.ts
+++ b/src/modules/accounting/accounting.controller.ts
@@ -58,6 +58,18 @@ export class AccountingController {
     return this.service.listAddresses(user.id);
   }
 
+  @Patch('addresses/:id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Update label of a tracked address' })
+  @ApiParam({ name: 'id' })
+  updateAddress(
+    @CurrentUser() user: User,
+    @Param('id') id: string,
+    @Body() body: { label?: string | null },
+  ) {
+    return this.service.updateAddress(user.id, id, body.label ?? null);
+  }
+
   @Delete('addresses/:id')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Remove a tracked address and its transfers' })
@@ -124,6 +136,24 @@ export class AccountingController {
   @ApiParam({ name: 'id' })
   getTokenBalances(@CurrentUser() user: User, @Param('id') id: string) {
     return this.service.getTokenBalances(user.id, id);
+  }
+
+  @Get('addresses/:id/token-overview')
+  @ApiOperation({ summary: 'Per-token asset/liability/net overview and per-classification totals' })
+  @ApiParam({ name: 'id' })
+  @ApiQuery({ name: 'year', required: false, type: Number })
+  @ApiQuery({ name: 'quarter', required: false, type: Number })
+  getTokenOverview(
+    @CurrentUser() user: User,
+    @Param('id') id: string,
+    @Query('year') year?: string,
+    @Query('quarter') quarter?: string,
+  ) {
+    return this.service.getTokenOverview(
+      user.id, id,
+      year ? parseInt(year, 10) : undefined,
+      quarter ? parseInt(quarter, 10) : undefined,
+    );
   }
 
   @Patch('transfers/:id')
@@ -310,5 +340,103 @@ export class AccountingController {
   @ApiParam({ name: 'id' })
   getJournalEntries(@CurrentUser() user: User, @Param('id') id: string) {
     return this.service.getJournalEntries(user.id, id);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Counterparty labels
+  // ---------------------------------------------------------------------------
+
+  @Get('counterparty-labels')
+  @ApiOperation({ summary: 'Get all counterparty address labels for the current user' })
+  getCounterpartyLabels(@CurrentUser() user: User) {
+    return this.service.getCounterpartyLabels(user.id);
+  }
+
+  @Post('counterparty-labels')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Upsert (or delete when label is null) a counterparty label' })
+  upsertCounterpartyLabel(
+    @CurrentUser() user: User,
+    @Body() body: { address: string; label: string | null },
+  ) {
+    return this.service.upsertCounterpartyLabel(user.id, body.address, body.label);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Token year-end prices
+  // ---------------------------------------------------------------------------
+
+  @Get('addresses/:id/token-prices')
+  @ApiOperation({ summary: 'Get user-entered year-end prices for all tokens of an address' })
+  @ApiParam({ name: 'id' })
+  @ApiQuery({ name: 'year', required: true, type: Number })
+  getTokenPrices(@CurrentUser() user: User, @Param('id') id: string, @Query('year') year: string) {
+    return this.service.getTokenPrices(user.id, id, parseInt(year, 10));
+  }
+
+  @Post('addresses/:id/token-prices')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Upsert a year-end CHF price for a token' })
+  @ApiParam({ name: 'id' })
+  upsertTokenPrice(
+    @CurrentUser() user: User,
+    @Param('id') id: string,
+    @Body() body: { year: number; tokenSymbol: string; priceChf: string | null },
+  ) {
+    return this.service.upsertTokenPrice(user.id, id, body.year, body.tokenSymbol, body.priceChf);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Adjustments (manual corrections / profit / loss entries)
+  // ---------------------------------------------------------------------------
+
+  @Get('addresses/:id/adjustments')
+  @ApiOperation({ summary: 'List manual adjustments for an address' })
+  @ApiParam({ name: 'id' })
+  @ApiQuery({ name: 'year', required: false, type: Number })
+  @ApiQuery({ name: 'quarter', required: false, type: Number })
+  getAdjustments(
+    @CurrentUser() user: User,
+    @Param('id') id: string,
+    @Query('year') year?: string,
+    @Query('quarter') quarter?: string,
+  ) {
+    return this.service.getAdjustments(
+      user.id, id,
+      year ? parseInt(year, 10) : undefined,
+      quarter ? parseInt(quarter, 10) : undefined,
+    );
+  }
+
+  @Post('addresses/:id/adjustments')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Create a manual adjustment entry' })
+  @ApiParam({ name: 'id' })
+  createAdjustment(
+    @CurrentUser() user: User,
+    @Param('id') id: string,
+    @Body() body: { date?: string; type: string; tokenSymbol?: string; amount?: string; chfValue?: string; note?: string },
+  ) {
+    return this.service.createAdjustment(user.id, id, body);
+  }
+
+  @Patch('adjustments/:id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Update a manual adjustment entry' })
+  @ApiParam({ name: 'id' })
+  updateAdjustment(
+    @CurrentUser() user: User,
+    @Param('id') id: string,
+    @Body() body: { date?: string; type?: string; tokenSymbol?: string | null; amount?: string | null; chfValue?: string | null; note?: string | null },
+  ) {
+    return this.service.updateAdjustment(user.id, id, body);
+  }
+
+  @Delete('adjustments/:id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a manual adjustment entry' })
+  @ApiParam({ name: 'id' })
+  deleteAdjustment(@CurrentUser() user: User, @Param('id') id: string) {
+    return this.service.deleteAdjustment(user.id, id);
   }
 }

--- a/src/modules/accounting/accounting.module.ts
+++ b/src/modules/accounting/accounting.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AccountingService } from './accounting.service';
+import { AccountingController } from './accounting.controller';
+import { DatabaseModule } from '../../core/database/database.module';
+import { AlchemyModule } from '../../integrations/alchemy/alchemy.module';
+
+@Module({
+  imports: [DatabaseModule, AlchemyModule],
+  providers: [AccountingService],
+  controllers: [AccountingController],
+})
+export class AccountingModule {}

--- a/src/modules/accounting/accounting.service.ts
+++ b/src/modules/accounting/accounting.service.ts
@@ -86,6 +86,12 @@ export class AccountingService {
     });
   }
 
+  async updateAddress(userId: string, id: string, label: string | null) {
+    const row = await this.prisma.accountingAddress.findFirst({ where: { id, userId } });
+    if (!row) throw new NotFoundException('Address not found');
+    return this.prisma.accountingAddress.update({ where: { id }, data: { label: label ?? null } });
+  }
+
   async removeAddress(userId: string, id: string) {
     const row = await this.prisma.accountingAddress.findFirst({ where: { id, userId } });
     if (!row) throw new NotFoundException('Address not found');
@@ -124,6 +130,10 @@ export class AccountingService {
       const blockNumber = t.blockNum ? parseInt(t.blockNum, 16) : null;
       const logIndex = parseLogIndex(t.uniqueId);
 
+      const symbol = t.asset ?? null;
+      const amountFormatted = t.value !== null && t.value !== undefined ? String(t.value) : null;
+      const isZchf = symbol?.toUpperCase() === 'ZCHF';
+
       return {
         accountingAddressId: acct.id,
         chainId: acct.chainId,
@@ -135,14 +145,15 @@ export class AccountingService {
         timestamp: t.metadata?.blockTimestamp ? new Date(t.metadata.blockTimestamp) : null,
         direction: t.to?.toLowerCase() === addr ? 'IN' : 'OUT',
         tokenAddress: tokenAddr,
-        tokenSymbol: t.asset ?? null,
+        tokenSymbol: symbol,
         tokenDecimals,
         tokenType: t.category,
         amountRaw: t.rawContract.value ?? null,
-        amountFormatted: t.value !== null && t.value !== undefined ? String(t.value) : null,
+        amountFormatted,
         fromAddress: t.from.toLowerCase(),
         toAddress: t.to?.toLowerCase() ?? null,
         isHidden: tokenAddr ? blacklisted.has(tokenAddr) : false,
+        chfValue: isZchf ? amountFormatted : undefined,
       };
     });
 
@@ -169,6 +180,20 @@ export class AccountingService {
         });
       await this.prisma.$transaction(updates);
       this.logger.log(`Backfilled block/log indices for ${updates.length} transfers`);
+    }
+
+    // Backfill chfValue for existing ZCHF transfers that are missing it
+    const zchfMissingChf = await this.prisma.accountingTransfer.findMany({
+      where: { accountingAddressId: acct.id, tokenSymbol: { equals: 'ZCHF', mode: 'insensitive' }, chfValue: null },
+      select: { id: true, amountFormatted: true },
+    });
+    if (zchfMissingChf.length > 0) {
+      await this.prisma.$transaction(
+        zchfMissingChf
+          .filter(t => t.amountFormatted !== null)
+          .map(t => this.prisma.accountingTransfer.update({ where: { id: t.id }, data: { chfValue: t.amountFormatted } })),
+      );
+      this.logger.log(`Backfilled CHF value for ${zchfMissingChf.length} ZCHF transfers`);
     }
 
     await this.prisma.accountingAddress.update({
@@ -589,6 +614,183 @@ export class AccountingService {
   }
 
   // ---------------------------------------------------------------------------
+  // Token overview — per-token asset/liability/net + per-classification totals
+  // ---------------------------------------------------------------------------
+
+  async getTokenOverview(userId: string, addressId: string, year?: number, quarter?: number) {
+    const acct = await this.prisma.accountingAddress.findFirst({ where: { id: addressId, userId } });
+    if (!acct) throw new NotFoundException('Address not found');
+
+    // Overview always accumulates from the beginning up to the END of the selected period
+    let timestampFilter: { lt: Date } | undefined;
+    if (year && quarter) {
+      const endMonth = quarter * 3 + 1;
+      timestampFilter = {
+        lt: endMonth > 12
+          ? new Date(`${year + 1}-01-01T00:00:00.000Z`)
+          : new Date(`${year}-${String(endMonth).padStart(2, '0')}-01T00:00:00.000Z`),
+      };
+    } else if (year) {
+      timestampFilter = {
+        lt: new Date(`${year + 1}-01-01T00:00:00.000Z`),
+      };
+    }
+
+    const transfers = await this.prisma.accountingTransfer.findMany({
+      where: { accountingAddressId: addressId, isHidden: false, ...(timestampFilter ? { timestamp: timestampFilter } : {}) },
+      select: {
+        tokenSymbol: true,
+        tokenAddress: true,
+        direction: true,
+        amountFormatted: true,
+        classification: true,
+        chfValue: true,
+      },
+    });
+
+    // Classifications that affect assets (signed by direction)
+    const ASSET_EFFECT = new Set<TransferClassification>([
+      TransferClassification.CAPITAL,
+      TransferClassification.INCOME,
+      TransferClassification.LOAN,
+      TransferClassification.REPAYMENT,
+      TransferClassification.SWAP_IN,
+      TransferClassification.SWAP_OUT,
+      TransferClassification.EXPENSE,
+      TransferClassification.PAYMENT,
+      // legacy
+      TransferClassification.ASSET,
+      TransferClassification.RECEIVED,
+      TransferClassification.LIABILITY,
+    ]);
+
+    // Classifications that also affect liabilities (signed by direction)
+    const LIABILITY_EFFECT = new Set<TransferClassification>([
+      TransferClassification.LOAN,
+      TransferClassification.REPAYMENT,
+      // legacy
+      TransferClassification.LIABILITY,
+    ]);
+
+    // No accounting effect
+    const NO_EFFECT = new Set<TransferClassification>([
+      TransferClassification.NEUTRAL,
+      TransferClassification.SKIPPED,
+      TransferClassification.TRANSFER,
+    ]);
+
+    type TokenEntry = {
+      tokenSymbol: string | null;
+      tokenAddress: string | null;
+      asset: number;
+      liability: number;
+      chfAsset: number;
+      chfLiability: number;
+    };
+    type ClassEntry = { count: number; total: number; chfTotal: number };
+
+    const tokenMap = new Map<string, TokenEntry>();
+    const classMap = new Map<string, ClassEntry>();
+    let unclassifiedCount = 0;
+
+    for (const t of transfers) {
+      if (t.classification === TransferClassification.UNCLASSIFIED) {
+        unclassifiedCount++;
+        continue;
+      }
+      if (NO_EFFECT.has(t.classification)) continue;
+
+      const amount = parseFloat(t.amountFormatted ?? '0') || 0;
+      const chf = parseFloat(t.chfValue ?? '0') || 0;
+      const signedAmount = t.direction === 'IN' ? amount : -amount;
+      const signedChf = t.direction === 'IN' ? chf : -chf;
+
+      const tokenKey = `${t.tokenAddress ?? '__native__'}:${t.tokenSymbol ?? ''}`;
+      if (!tokenMap.has(tokenKey)) {
+        tokenMap.set(tokenKey, { tokenSymbol: t.tokenSymbol, tokenAddress: t.tokenAddress, asset: 0, liability: 0, chfAsset: 0, chfLiability: 0 });
+      }
+      const entry = tokenMap.get(tokenKey)!;
+
+      if (ASSET_EFFECT.has(t.classification)) {
+        entry.asset += signedAmount;
+        entry.chfAsset += signedChf;
+      }
+      if (LIABILITY_EFFECT.has(t.classification)) {
+        entry.liability += signedAmount;
+        entry.chfLiability += signedChf;
+      }
+
+      const ce = classMap.get(t.classification) ?? { count: 0, total: 0, chfTotal: 0 };
+      ce.count++;
+      ce.total += signedAmount;
+      ce.chfTotal += signedChf;
+      classMap.set(t.classification, ce);
+    }
+
+    // Fold manual adjustments into the token map
+    const adjustments = await this.prisma.accountingAdjustment.findMany({
+      where: { accountingAddressId: addressId, ...(timestampFilter ? { date: timestampFilter } : {}) },
+    });
+
+    for (const adj of adjustments) {
+      // Merge into an existing token entry matched by symbol; create a new one only if none exists
+      const symLower = adj.tokenSymbol?.toLowerCase();
+      let tokenKey = symLower
+        ? [...tokenMap.keys()].find(k => tokenMap.get(k)!.tokenSymbol?.toLowerCase() === symLower)
+        : undefined;
+      if (!tokenKey) {
+        tokenKey = `__adj__:${adj.tokenSymbol ?? '__general__'}`;
+        tokenMap.set(tokenKey, { tokenSymbol: adj.tokenSymbol, tokenAddress: null, asset: 0, liability: 0, chfAsset: 0, chfLiability: 0 });
+      }
+      const entry = tokenMap.get(tokenKey)!;
+
+      const amount = parseFloat(adj.amount ?? '0') || 0;
+      const chf = parseFloat(adj.chfValue ?? '0') || 0;
+
+      if (adj.type === 'PROFIT') {
+        entry.asset    += amount;
+        entry.chfAsset += chf;
+      } else if (adj.type === 'LOSS') {
+        entry.asset    -= amount;
+        entry.chfAsset -= chf;
+      } else if (adj.type === 'BORROW') {
+        entry.liability    -= amount;
+        entry.chfLiability -= chf;
+      } else if (adj.type === 'REPAYMENT') {
+        entry.liability    += amount;
+        entry.chfLiability += chf;
+      }
+
+      // Surface in byClassification as INCOME (received) or EXPENSE (sent out)
+      const isPositive = adj.type === 'PROFIT' || adj.type === 'BORROW';
+      const adjClass = isPositive ? TransferClassification.INCOME : TransferClassification.EXPENSE;
+      const adjSign = isPositive ? 1 : -1;
+      const ce = classMap.get(adjClass) ?? { count: 0, total: 0, chfTotal: 0 };
+      ce.count++;
+      ce.total += adj.amount ? adjSign * (parseFloat(adj.amount) || 0) : 0;
+      ce.chfTotal += adj.chfValue ? adjSign * (parseFloat(adj.chfValue) || 0) : 0;
+      classMap.set(adjClass, ce);
+    }
+
+    const tokens = Array.from(tokenMap.values())
+      .map(t => ({ ...t, net: t.asset - t.liability, chfNet: t.chfAsset - t.chfLiability }))
+      .sort((a, b) => Math.abs(b.chfAsset) - Math.abs(a.chfAsset));
+
+    const byClassification = Array.from(classMap.entries())
+      .map(([classification, data]) => ({ classification, ...data }))
+      .sort((a, b) => b.total - a.total);
+
+    // Distinct years across all (non-hidden) transfers for this address
+    const allTimestamps = await this.prisma.accountingTransfer.findMany({
+      where: { accountingAddressId: addressId, isHidden: false, timestamp: { not: null } },
+      select: { timestamp: true },
+    });
+    const years = [...new Set(allTimestamps.map(t => t.timestamp!.getFullYear()))].sort((a, b) => b - a);
+
+    return { address: acct, tokens, byClassification, unclassifiedCount, years };
+  }
+
+  // ---------------------------------------------------------------------------
   // Legacy summary (kept for backwards compat)
   // ---------------------------------------------------------------------------
 
@@ -647,5 +849,137 @@ export class AccountingService {
       data: DEFAULT_ACCOUNTS.map(a => ({ ...a, userId })),
       skipDuplicates: true,
     });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Counterparty labels (global per user — address → friendly name)
+  // ---------------------------------------------------------------------------
+
+  async getCounterpartyLabels(userId: string): Promise<Record<string, string>> {
+    const rows = await this.prisma.accountingCounterpartyLabel.findMany({ where: { userId } });
+    return Object.fromEntries(rows.map(r => [r.address, r.label]));
+  }
+
+  async upsertCounterpartyLabel(userId: string, address: string, label: string | null) {
+    const normalised = address.toLowerCase();
+    if (!label) {
+      await this.prisma.accountingCounterpartyLabel.deleteMany({ where: { userId, address: normalised } });
+      return null;
+    }
+    return this.prisma.accountingCounterpartyLabel.upsert({
+      where: { userId_address: { userId, address: normalised } },
+      create: { userId, address: normalised, label },
+      update: { label },
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Token year-end prices (user-entered, per address + year)
+  // ---------------------------------------------------------------------------
+
+  async getTokenPrices(userId: string, addressId: string, year: number): Promise<Record<string, string>> {
+    const acct = await this.prisma.accountingAddress.findFirst({ where: { id: addressId, userId } });
+    if (!acct) throw new NotFoundException('Address not found');
+    const rows = await this.prisma.accountingTokenPrice.findMany({ where: { accountingAddressId: addressId, year } });
+    return Object.fromEntries(rows.map(r => [r.tokenSymbol, r.priceChf]));
+  }
+
+  async upsertTokenPrice(userId: string, addressId: string, year: number, tokenSymbol: string, priceChf: string | null) {
+    const acct = await this.prisma.accountingAddress.findFirst({ where: { id: addressId, userId } });
+    if (!acct) throw new NotFoundException('Address not found');
+    if (!priceChf) {
+      await this.prisma.accountingTokenPrice.deleteMany({ where: { accountingAddressId: addressId, year, tokenSymbol } });
+      return null;
+    }
+    return this.prisma.accountingTokenPrice.upsert({
+      where: { accountingAddressId_year_tokenSymbol: { accountingAddressId: addressId, year, tokenSymbol } },
+      create: { accountingAddressId: addressId, year, tokenSymbol, priceChf },
+      update: { priceChf },
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Adjustments (manual corrections / profit / loss entries)
+  // ---------------------------------------------------------------------------
+
+  async getAdjustments(userId: string, addressId: string, year?: number, quarter?: number) {
+    const acct = await this.prisma.accountingAddress.findFirst({ where: { id: addressId, userId } });
+    if (!acct) throw new NotFoundException('Address not found');
+
+    let dateFilter: { gte?: Date; lt?: Date } | undefined;
+    if (year && quarter) {
+      const startMonth = (quarter - 1) * 3 + 1;
+      const endMonth = startMonth + 3;
+      dateFilter = {
+        gte: new Date(`${year}-${String(startMonth).padStart(2, '0')}-01T00:00:00.000Z`),
+        lt: endMonth > 12
+          ? new Date(`${year + 1}-01-01T00:00:00.000Z`)
+          : new Date(`${year}-${String(endMonth).padStart(2, '0')}-01T00:00:00.000Z`),
+      };
+    } else if (year) {
+      dateFilter = {
+        gte: new Date(`${year}-01-01T00:00:00.000Z`),
+        lt: new Date(`${year + 1}-01-01T00:00:00.000Z`),
+      };
+    }
+
+    return this.prisma.accountingAdjustment.findMany({
+      where: { accountingAddressId: addressId, ...(dateFilter ? { date: dateFilter } : {}) },
+      orderBy: { date: 'desc' },
+    });
+  }
+
+  async createAdjustment(
+    userId: string,
+    addressId: string,
+    body: { date?: string; type: string; tokenSymbol?: string; amount?: string; chfValue?: string; note?: string },
+  ) {
+    const acct = await this.prisma.accountingAddress.findFirst({ where: { id: addressId, userId } });
+    if (!acct) throw new NotFoundException('Address not found');
+
+    return this.prisma.accountingAdjustment.create({
+      data: {
+        accountingAddressId: addressId,
+        date: body.date ? new Date(body.date) : new Date(),
+        type: body.type,
+        tokenSymbol: body.tokenSymbol ?? null,
+        amount: body.amount ?? null,
+        chfValue: body.chfValue ?? null,
+        note: body.note ?? null,
+      },
+    });
+  }
+
+  async updateAdjustment(
+    userId: string,
+    id: string,
+    body: { date?: string; type?: string; tokenSymbol?: string | null; amount?: string | null; chfValue?: string | null; note?: string | null },
+  ) {
+    const adj = await this.prisma.accountingAdjustment.findFirst({
+      where: { id },
+      include: { accountingAddress: true },
+    });
+    if (!adj || adj.accountingAddress.userId !== userId) throw new NotFoundException('Adjustment not found');
+
+    return this.prisma.accountingAdjustment.update({
+      where: { id },
+      data: {
+        ...(body.date !== undefined ? { date: new Date(body.date) } : {}),
+        ...(body.type !== undefined ? { type: body.type } : {}),
+        ...(body.tokenSymbol !== undefined ? { tokenSymbol: body.tokenSymbol } : {}),
+        ...(body.amount !== undefined ? { amount: body.amount } : {}),
+        ...(body.chfValue !== undefined ? { chfValue: body.chfValue } : {}),
+        ...(body.note !== undefined ? { note: body.note } : {}),
+      },
+    });
+  }
+
+  async deleteAdjustment(userId: string, id: string) {
+    const adj = await this.prisma.accountingAdjustment.findFirst({
+      where: { id },
+      include: { accountingAddress: true },
+    });
+    if (!adj || adj.accountingAddress.userId !== userId) throw new NotFoundException('Adjustment not found');
+    await this.prisma.accountingAdjustment.delete({ where: { id } });
   }
 }

--- a/src/modules/accounting/accounting.service.ts
+++ b/src/modules/accounting/accounting.service.ts
@@ -1,0 +1,651 @@
+import { Injectable, NotFoundException, ConflictException, Logger } from '@nestjs/common';
+import {
+  TransferClassification,
+  AccountType,
+  NormalBalance,
+  JournalLineType,
+} from '@prisma/client';
+import { PrismaService } from '../../core/database/prisma.service';
+import { AlchemyService } from '../../integrations/alchemy/alchemy.service';
+
+const CHAIN_ID_MAP: Record<string, number> = {
+  'eth-mainnet':     1,
+  'polygon-mainnet': 137,
+  'opt-mainnet':     10,
+  'arb-mainnet':     42161,
+  'base-mainnet':    8453,
+};
+
+const MAX_PER_PAGE = 1000;
+
+// Extracts the numeric log/event index from Alchemy uniqueId.
+// Format: "<txHash>:log:<n>" where <n> may be decimal ("145") or hex ("0x91").
+// parseInt without a radix auto-detects the 0x prefix — do NOT pass radix 10.
+function parseLogIndex(uniqueId: string): number {
+  const last = uniqueId.split(':').at(-1);
+  const n = parseInt(last ?? '');
+  return isNaN(n) ? 0 : n;
+}
+
+// ---------------------------------------------------------------------------
+// Default chart of accounts
+// ---------------------------------------------------------------------------
+
+const DEFAULT_ACCOUNTS = [
+  { name: 'Crypto Assets',      code: '1000', type: AccountType.ASSET,     normalBalance: NormalBalance.DEBIT  },
+  { name: 'Internal Transfers', code: '1900', type: AccountType.ASSET,     normalBalance: NormalBalance.DEBIT  },
+  { name: 'Loans Payable',      code: '2000', type: AccountType.LIABILITY, normalBalance: NormalBalance.CREDIT },
+  { name: 'Equity',             code: '3000', type: AccountType.EQUITY,    normalBalance: NormalBalance.CREDIT },
+  { name: 'Income',             code: '4000', type: AccountType.REVENUE,   normalBalance: NormalBalance.CREDIT },
+  { name: 'Swap Proceeds',      code: '4100', type: AccountType.REVENUE,   normalBalance: NormalBalance.CREDIT },
+  { name: 'Expenses',           code: '6000', type: AccountType.EXPENSE,   normalBalance: NormalBalance.DEBIT  },
+  { name: 'Swap Cost',          code: '6100', type: AccountType.EXPENSE,   normalBalance: NormalBalance.DEBIT  },
+];
+
+// Default debit/credit account names per classification + direction.
+// Direction "ANY" matches both IN and OUT when no direction-specific template exists.
+const DEFAULT_TEMPLATES: Record<string, { debit: string; credit: string }> = {
+  [`${TransferClassification.ASSET}:ANY`]:     { debit: 'Crypto Assets', credit: 'Income'          },
+  [`${TransferClassification.RECEIVED}:ANY`]:  { debit: 'Crypto Assets', credit: 'Income'          },
+  [`${TransferClassification.SWAP_IN}:ANY`]:   { debit: 'Crypto Assets', credit: 'Swap Proceeds'   },
+  [`${TransferClassification.LIABILITY}:ANY`]: { debit: 'Crypto Assets', credit: 'Loans Payable'   },
+  [`${TransferClassification.PAYMENT}:ANY`]:   { debit: 'Expenses',      credit: 'Crypto Assets'   },
+  [`${TransferClassification.SWAP_OUT}:ANY`]:  { debit: 'Swap Cost',     credit: 'Crypto Assets'   },
+  [`${TransferClassification.TRANSFER}:IN`]:   { debit: 'Crypto Assets', credit: 'Internal Transfers' },
+  [`${TransferClassification.TRANSFER}:OUT`]:  { debit: 'Internal Transfers', credit: 'Crypto Assets'  },
+};
+
+@Injectable()
+export class AccountingService {
+  private readonly logger = new Logger(AccountingService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly alchemy: AlchemyService,
+  ) {}
+
+  // ---------------------------------------------------------------------------
+  // Addresses
+  // ---------------------------------------------------------------------------
+
+  async addAddress(userId: string, address: string, chain: string, label?: string) {
+    const chainId = CHAIN_ID_MAP[chain];
+    if (!chainId) throw new ConflictException(`Unsupported chain: ${chain}`);
+    const normalised = address.toLowerCase();
+    return this.prisma.accountingAddress.upsert({
+      where: { userId_address_chainId: { userId, address: normalised, chainId } },
+      create: { userId, address: normalised, chain, chainId, label },
+      update: { label, chain },
+    });
+  }
+
+  async listAddresses(userId: string) {
+    return this.prisma.accountingAddress.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'asc' },
+    });
+  }
+
+  async removeAddress(userId: string, id: string) {
+    const row = await this.prisma.accountingAddress.findFirst({ where: { id, userId } });
+    if (!row) throw new NotFoundException('Address not found');
+    await this.prisma.accountingAddress.delete({ where: { id } });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Sync
+  // ---------------------------------------------------------------------------
+
+  async syncAddress(userId: string, id: string): Promise<{ synced: number }> {
+    const acct = await this.prisma.accountingAddress.findFirst({ where: { id, userId } });
+    if (!acct) throw new NotFoundException('Address not found');
+
+    const blacklist = await this.prisma.accountingBlacklist.findMany({
+      where: { chainId: acct.chainId },
+      select: { tokenAddress: true },
+    });
+    const blacklisted = new Set(blacklist.map(b => b.tokenAddress.toLowerCase()));
+
+    const all = await this.fetchAllTransfers(acct.chain, acct.address);
+    const seen = new Set<string>();
+    const unique = all.filter(t => {
+      if (seen.has(t.uniqueId)) return false;
+      seen.add(t.uniqueId);
+      return true;
+    });
+
+    const addr = acct.address.toLowerCase();
+    const rows = unique.map(t => {
+      const tokenAddr = t.rawContract.address?.toLowerCase() ?? null;
+      const decimalsHex = t.rawContract.decimal;
+      const tokenDecimals = decimalsHex
+        ? (decimalsHex.startsWith('0x') ? parseInt(decimalsHex, 16) : parseInt(decimalsHex, 10))
+        : null;
+      const blockNumber = t.blockNum ? parseInt(t.blockNum, 16) : null;
+      const logIndex = parseLogIndex(t.uniqueId);
+
+      return {
+        accountingAddressId: acct.id,
+        chainId: acct.chainId,
+        txHash: t.hash,
+        alchemyUniqueId: t.uniqueId,
+        blockNum: t.blockNum,
+        blockNumber,
+        logIndex,
+        timestamp: t.metadata?.blockTimestamp ? new Date(t.metadata.blockTimestamp) : null,
+        direction: t.to?.toLowerCase() === addr ? 'IN' : 'OUT',
+        tokenAddress: tokenAddr,
+        tokenSymbol: t.asset ?? null,
+        tokenDecimals,
+        tokenType: t.category,
+        amountRaw: t.rawContract.value ?? null,
+        amountFormatted: t.value !== null && t.value !== undefined ? String(t.value) : null,
+        fromAddress: t.from.toLowerCase(),
+        toAddress: t.to?.toLowerCase() ?? null,
+        isHidden: tokenAddr ? blacklisted.has(tokenAddr) : false,
+      };
+    });
+
+    const result = await this.prisma.accountingTransfer.createMany({
+      data: rows,
+      skipDuplicates: true,
+    });
+
+    // Backfill blockNumber/logIndex for records synced before these fields existed
+    const metaMap = new Map(rows.map(r => [r.alchemyUniqueId, { blockNumber: r.blockNumber, logIndex: r.logIndex }]));
+    const needsBackfill = await this.prisma.accountingTransfer.findMany({
+      where: { accountingAddressId: acct.id, logIndex: null },
+      select: { id: true, alchemyUniqueId: true },
+    });
+    if (needsBackfill.length > 0) {
+      const updates = needsBackfill
+        .filter(r => metaMap.has(r.alchemyUniqueId))
+        .map(r => {
+          const meta = metaMap.get(r.alchemyUniqueId)!;
+          return this.prisma.accountingTransfer.update({
+            where: { id: r.id },
+            data: { blockNumber: meta.blockNumber, logIndex: meta.logIndex },
+          });
+        });
+      await this.prisma.$transaction(updates);
+      this.logger.log(`Backfilled block/log indices for ${updates.length} transfers`);
+    }
+
+    await this.prisma.accountingAddress.update({
+      where: { id: acct.id },
+      data: { lastSyncedAt: new Date() },
+    });
+
+    this.logger.log(`Synced ${result.count} new transfers for ${acct.address}`);
+    return { synced: result.count };
+  }
+
+  private async fetchAllTransfers(chain: string, address: string) {
+    const transfers = [];
+    for (const dir of ['from', 'to'] as const) {
+      let pageKey: string | undefined;
+      do {
+        const res = await this.alchemy.getTokenTransfers(chain, address, dir, MAX_PER_PAGE, pageKey);
+        transfers.push(...res.transfers);
+        pageKey = res.pageKey;
+      } while (pageKey);
+    }
+    return transfers;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Transfers
+  // ---------------------------------------------------------------------------
+
+  async getTransfers(
+    userId: string,
+    addressId: string,
+    opts: {
+      search?: string;
+      classification?: string;
+      direction?: string;
+      showHidden?: boolean;
+      skip?: number;
+      take?: number;
+      sortBy?: string;
+      sortDir?: 'asc' | 'desc';
+    },
+  ) {
+    const acct = await this.prisma.accountingAddress.findFirst({ where: { id: addressId, userId } });
+    if (!acct) throw new NotFoundException('Address not found');
+
+    const where: any = { accountingAddressId: addressId };
+    if (!opts.showHidden) where.isHidden = false;
+    if (opts.direction) where.direction = opts.direction;
+    if (opts.classification) where.classification = opts.classification as TransferClassification;
+
+    if (opts.search) {
+      const q = opts.search.toLowerCase();
+      where.OR = [
+        { tokenSymbol: { contains: q, mode: 'insensitive' } },
+        { txHash: { contains: q, mode: 'insensitive' } },
+        { fromAddress: { contains: q, mode: 'insensitive' } },
+        { toAddress: { contains: q, mode: 'insensitive' } },
+      ];
+    }
+
+    const sortField = opts.sortBy ?? 'timestamp';
+    const sortDir = opts.sortDir ?? 'desc';
+    const orderBy: any =
+      sortField === 'timestamp'
+        ? [{ timestamp: sortDir }, { blockNumber: sortDir }, { logIndex: sortDir }]
+        : { [sortField]: sortDir };
+
+    const [total, transfers] = await Promise.all([
+      this.prisma.accountingTransfer.count({ where }),
+      this.prisma.accountingTransfer.findMany({ where, orderBy, skip: opts.skip ?? 0, take: opts.take ?? 50 }),
+    ]);
+
+    return { total, transfers };
+  }
+
+  async updateTransfer(
+    userId: string,
+    transferId: string,
+    data: { classification?: TransferClassification; isHidden?: boolean; chfValue?: string | null; notes?: string | null },
+  ) {
+    const transfer = await this.prisma.accountingTransfer.findUnique({
+      where: { id: transferId },
+      include: { accountingAddress: { select: { userId: true } } },
+    });
+    if (!transfer || transfer.accountingAddress.userId !== userId) {
+      throw new NotFoundException('Transfer not found');
+    }
+
+    const updated = await this.prisma.accountingTransfer.update({ where: { id: transferId }, data });
+
+    // Keep journal entry in sync whenever classification or chfValue changes
+    const newClassification = data.classification ?? transfer.classification;
+    if (data.classification !== undefined || data.chfValue !== undefined) {
+      if (
+        newClassification === TransferClassification.UNCLASSIFIED ||
+        newClassification === TransferClassification.SKIPPED
+      ) {
+        await this.prisma.journalEntry.deleteMany({ where: { transferId } });
+      } else {
+        await this.upsertJournalEntry(userId, updated);
+      }
+    }
+
+    return updated;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Journal entries (private helpers)
+  // ---------------------------------------------------------------------------
+
+  private async upsertJournalEntry(userId: string, transfer: any): Promise<void> {
+    const accounts = await this.getAccountMap(userId);
+    const { debitId, creditId } = await this.resolveTemplate(userId, transfer, accounts);
+
+    if (!debitId || !creditId) {
+      this.logger.warn(`No accounts found for journal entry on transfer ${transfer.id}`);
+      return;
+    }
+
+    const amount = transfer.amountFormatted ?? '0';
+    const chf = transfer.chfValue ?? null;
+
+    await this.prisma.journalEntry.upsert({
+      where: { transferId: transfer.id },
+      create: {
+        transferId: transfer.id,
+        date: transfer.timestamp ?? transfer.createdAt,
+        description: `${transfer.tokenSymbol ?? '?'} ${transfer.direction} — ${transfer.txHash.slice(0, 10)}`,
+        lines: {
+          create: [
+            { accountId: debitId,  type: JournalLineType.DEBIT,  amount, chfAmount: chf, tokenSymbol: transfer.tokenSymbol },
+            { accountId: creditId, type: JournalLineType.CREDIT, amount, chfAmount: chf, tokenSymbol: transfer.tokenSymbol },
+          ],
+        },
+      },
+      update: {
+        date: transfer.timestamp ?? transfer.createdAt,
+        description: `${transfer.tokenSymbol ?? '?'} ${transfer.direction} — ${transfer.txHash.slice(0, 10)}`,
+        lines: {
+          deleteMany: {},
+          create: [
+            { accountId: debitId,  type: JournalLineType.DEBIT,  amount, chfAmount: chf, tokenSymbol: transfer.tokenSymbol },
+            { accountId: creditId, type: JournalLineType.CREDIT, amount, chfAmount: chf, tokenSymbol: transfer.tokenSymbol },
+          ],
+        },
+      },
+    });
+  }
+
+  private async resolveTemplate(
+    userId: string,
+    transfer: { classification: TransferClassification; direction: string },
+    accountMap: Map<string, string>,
+  ): Promise<{ debitId: string | undefined; creditId: string | undefined }> {
+    // Prefer direction-specific user override, fall back to ANY, then hardcoded defaults
+    const [specificRow, anyRow] = await Promise.all([
+      this.prisma.classificationTemplate.findFirst({
+        where: { userId, classification: transfer.classification, direction: transfer.direction },
+      }),
+      this.prisma.classificationTemplate.findFirst({
+        where: { userId, classification: transfer.classification, direction: 'ANY' },
+      }),
+    ]);
+    const dbRow = specificRow ?? anyRow;
+
+    if (dbRow) {
+      return { debitId: dbRow.debitAccountId, creditId: dbRow.creditAccountId };
+    }
+
+    const dirKey = `${transfer.classification}:${transfer.direction}`;
+    const anyKey = `${transfer.classification}:ANY`;
+    const tmpl = DEFAULT_TEMPLATES[dirKey] ?? DEFAULT_TEMPLATES[anyKey];
+
+    if (!tmpl) return { debitId: undefined, creditId: undefined };
+    return {
+      debitId:  accountMap.get(tmpl.debit),
+      creditId: accountMap.get(tmpl.credit),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Chart of accounts
+  // ---------------------------------------------------------------------------
+
+  async getAccounts(userId: string) {
+    await this.ensureDefaultAccounts(userId);
+    return this.prisma.accountingAccount.findMany({
+      where: { userId },
+      orderBy: [{ type: 'asc' }, { code: 'asc' }, { name: 'asc' }],
+    });
+  }
+
+  async createAccount(
+    userId: string,
+    data: { name: string; code?: string; type: AccountType; normalBalance: NormalBalance; description?: string },
+  ) {
+    return this.prisma.accountingAccount.create({ data: { userId, ...data } });
+  }
+
+  async updateAccount(
+    userId: string,
+    id: string,
+    data: { name?: string; code?: string; description?: string },
+  ) {
+    const row = await this.prisma.accountingAccount.findFirst({ where: { id, userId } });
+    if (!row) throw new NotFoundException('Account not found');
+    return this.prisma.accountingAccount.update({ where: { id }, data });
+  }
+
+  async deleteAccount(userId: string, id: string) {
+    const row = await this.prisma.accountingAccount.findFirst({ where: { id, userId } });
+    if (!row) throw new NotFoundException('Account not found');
+    const usedBy = await this.prisma.journalLine.count({ where: { accountId: id } });
+    if (usedBy > 0) throw new ConflictException('Account has journal entries and cannot be deleted');
+    await this.prisma.accountingAccount.delete({ where: { id } });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Classification templates
+  // ---------------------------------------------------------------------------
+
+  async getTemplates(userId: string) {
+    await this.ensureDefaultAccounts(userId);
+    const userTemplates = await this.prisma.classificationTemplate.findMany({
+      where: { userId },
+      include: { debitAccount: true, creditAccount: true },
+      orderBy: [{ classification: 'asc' }, { direction: 'asc' }],
+    });
+
+    // Merge with hardcoded defaults so the UI always shows all rows
+    const accountMap = await this.getAccountMap(userId);
+    const reverseMap = new Map(Array.from(accountMap.entries()).map(([name, id]) => [id, name]));
+
+    const result = Object.entries(DEFAULT_TEMPLATES).map(([key, defaults]) => {
+      const [classification, direction] = key.split(':') as [TransferClassification, string];
+      const override = userTemplates.find(
+        t => t.classification === classification && t.direction === direction,
+      );
+      return {
+        classification,
+        direction,
+        debitAccountId:   override?.debitAccountId  ?? accountMap.get(defaults.debit),
+        creditAccountId:  override?.creditAccountId ?? accountMap.get(defaults.credit),
+        debitAccountName: override ? reverseMap.get(override.debitAccountId)  : defaults.debit,
+        creditAccountName: override ? reverseMap.get(override.creditAccountId) : defaults.credit,
+        isOverridden: !!override,
+        id: override?.id,
+      };
+    });
+
+    return result;
+  }
+
+  async upsertTemplate(
+    userId: string,
+    data: {
+      classification: TransferClassification;
+      direction: string;
+      debitAccountId: string;
+      creditAccountId: string;
+    },
+  ) {
+    // Verify both accounts belong to this user
+    const [debit, credit] = await Promise.all([
+      this.prisma.accountingAccount.findFirst({ where: { id: data.debitAccountId, userId } }),
+      this.prisma.accountingAccount.findFirst({ where: { id: data.creditAccountId, userId } }),
+    ]);
+    if (!debit || !credit) throw new NotFoundException('Account not found');
+
+    return this.prisma.classificationTemplate.upsert({
+      where: { userId_classification_direction: { userId, classification: data.classification, direction: data.direction } },
+      create: { userId, ...data },
+      update: { debitAccountId: data.debitAccountId, creditAccountId: data.creditAccountId },
+    });
+  }
+
+  async deleteTemplate(userId: string, id: string) {
+    const row = await this.prisma.classificationTemplate.findFirst({ where: { id, userId } });
+    if (!row) throw new NotFoundException('Template not found');
+    await this.prisma.classificationTemplate.delete({ where: { id } });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Trial balance
+  // ---------------------------------------------------------------------------
+
+  async getTrialBalance(userId: string, addressId?: string) {
+    await this.ensureDefaultAccounts(userId);
+
+    const accounts = await this.prisma.accountingAccount.findMany({
+      where: { userId },
+      orderBy: [{ type: 'asc' }, { code: 'asc' }, { name: 'asc' }],
+    });
+
+    const lines = await this.prisma.journalLine.findMany({
+      where: {
+        journalEntry: {
+          transfer: {
+            accountingAddress: {
+              userId,
+              ...(addressId ? { id: addressId } : {}),
+            },
+          },
+        },
+      },
+      select: { accountId: true, type: true, amount: true, chfAmount: true },
+    });
+
+    const totals = new Map<string, { debit: number; credit: number; chfDebit: number; chfCredit: number }>();
+
+    for (const line of lines) {
+      if (!totals.has(line.accountId)) {
+        totals.set(line.accountId, { debit: 0, credit: 0, chfDebit: 0, chfCredit: 0 });
+      }
+      const t = totals.get(line.accountId)!;
+      const amt = parseFloat(line.amount) || 0;
+      const chf = parseFloat(line.chfAmount ?? '0') || 0;
+      if (line.type === JournalLineType.DEBIT)  { t.debit  += amt; t.chfDebit  += chf; }
+      else                                       { t.credit += amt; t.chfCredit += chf; }
+    }
+
+    return accounts.map(acc => {
+      const t = totals.get(acc.id) ?? { debit: 0, credit: 0, chfDebit: 0, chfCredit: 0 };
+      const net    = acc.normalBalance === NormalBalance.DEBIT ? t.debit - t.credit   : t.credit - t.debit;
+      const chfNet = acc.normalBalance === NormalBalance.DEBIT ? t.chfDebit - t.chfCredit : t.chfCredit - t.chfDebit;
+      return { ...acc, ...t, net, chfNet };
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Journal entries (for display)
+  // ---------------------------------------------------------------------------
+
+  async getJournalEntries(userId: string, addressId: string) {
+    const acct = await this.prisma.accountingAddress.findFirst({ where: { id: addressId, userId } });
+    if (!acct) throw new NotFoundException('Address not found');
+
+    return this.prisma.journalEntry.findMany({
+      where: { transfer: { accountingAddressId: addressId } },
+      include: {
+        lines: { include: { account: true } },
+        transfer: { select: { tokenSymbol: true, direction: true, txHash: true, classification: true } },
+      },
+      orderBy: { date: 'desc' },
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Token balances — per-token IN/OUT/balance aggregation
+  // ---------------------------------------------------------------------------
+
+  async getTokenBalances(userId: string, addressId: string) {
+    const acct = await this.prisma.accountingAddress.findFirst({ where: { id: addressId, userId } });
+    if (!acct) throw new NotFoundException('Address not found');
+
+    const transfers = await this.prisma.accountingTransfer.findMany({
+      where: { accountingAddressId: addressId, isHidden: false },
+      select: {
+        tokenSymbol: true,
+        tokenAddress: true,
+        tokenType: true,
+        direction: true,
+        amountFormatted: true,
+        classification: true,
+        chfValue: true,
+      },
+    });
+
+    type TokenKey = string;
+    const map = new Map<TokenKey, {
+      tokenSymbol: string | null;
+      tokenAddress: string | null;
+      tokenType: string;
+      totalIn: number;
+      totalOut: number;
+      chfTotal: number;
+      byClassification: Record<string, number>;
+      inCount: number;
+      outCount: number;
+    }>();
+
+    for (const t of transfers) {
+      const key: TokenKey = `${t.tokenAddress ?? '__native__'}:${t.tokenSymbol ?? ''}`;
+      if (!map.has(key)) {
+        map.set(key, {
+          tokenSymbol: t.tokenSymbol,
+          tokenAddress: t.tokenAddress,
+          tokenType: t.tokenType,
+          totalIn: 0,
+          totalOut: 0,
+          chfTotal: 0,
+          byClassification: {},
+          inCount: 0,
+          outCount: 0,
+        });
+      }
+      const entry = map.get(key)!;
+      const amount = parseFloat(t.amountFormatted ?? '0') || 0;
+      const chf = parseFloat(t.chfValue ?? '0') || 0;
+
+      if (t.direction === 'IN') {
+        entry.totalIn += amount;
+        entry.inCount += 1;
+      } else {
+        entry.totalOut += amount;
+        entry.outCount += 1;
+      }
+      entry.chfTotal += chf;
+      entry.byClassification[t.classification] = (entry.byClassification[t.classification] ?? 0) + amount;
+    }
+
+    return {
+      address: acct,
+      tokens: Array.from(map.values())
+        .map(t => ({ ...t, balance: t.totalIn - t.totalOut }))
+        .sort((a, b) => Math.abs(b.totalIn + b.totalOut) - Math.abs(a.totalIn + a.totalOut)),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Legacy summary (kept for backwards compat)
+  // ---------------------------------------------------------------------------
+
+  async getSummary(userId: string, addressId: string) {
+    const acct = await this.prisma.accountingAddress.findFirst({ where: { id: addressId, userId } });
+    if (!acct) throw new NotFoundException('Address not found');
+    const tb = await this.getTrialBalance(userId, addressId);
+    return { address: acct, trialBalance: tb };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Blacklist
+  // ---------------------------------------------------------------------------
+
+  async getBlacklist() {
+    return this.prisma.accountingBlacklist.findMany({ orderBy: { createdAt: 'desc' } });
+  }
+
+  async addToBlacklist(userId: string, tokenAddress: string, chainId: number, tokenSymbol?: string, reason?: string) {
+    const normalised = tokenAddress.toLowerCase();
+    const entry = await this.prisma.accountingBlacklist.upsert({
+      where: { tokenAddress_chainId: { tokenAddress: normalised, chainId } },
+      create: { tokenAddress: normalised, chainId, tokenSymbol, reason, addedByUserId: userId },
+      update: { tokenSymbol, reason },
+    });
+    await this.prisma.accountingTransfer.updateMany({
+      where: { tokenAddress: normalised, chainId },
+      data: { isHidden: true },
+    });
+    return entry;
+  }
+
+  async removeFromBlacklist(id: string) {
+    const row = await this.prisma.accountingBlacklist.findUnique({ where: { id } });
+    if (!row) throw new NotFoundException('Blacklist entry not found');
+    await this.prisma.accountingBlacklist.delete({ where: { id } });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private async getAccountMap(userId: string): Promise<Map<string, string>> {
+    const accounts = await this.prisma.accountingAccount.findMany({
+      where: { userId },
+      select: { id: true, name: true },
+    });
+    return new Map(accounts.map(a => [a.name, a.id]));
+  }
+
+  private async ensureDefaultAccounts(userId: string): Promise<void> {
+    const count = await this.prisma.accountingAccount.count({ where: { userId } });
+    if (count > 0) return;
+
+    await this.prisma.accountingAccount.createMany({
+      data: DEFAULT_ACCOUNTS.map(a => ({ ...a, userId })),
+      skipDuplicates: true,
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- **Accounting module** — double-entry bookkeeping, token transfers, chart of accounts; full REST API with adjustments, token prices, counterparty/address labels, and overview endpoints
- **Conservative gas pricing** — `conservativeGasFees()` in `WalletViemService` caps the priority fee at 0.2 gwei and enforces a hard base fee ceiling (0.3 gwei for testing); throws `GasTooHighError` which triggers a silent 5-minute retry loop (up to 5 days) rather than failing the execution
- **1inch direct-to-Kraken swap** — when a conversion strategy outputs a Kraken-mapped token, the swap `receiver` is set to the Kraken deposit address directly, saving a separate Safe→Kraken transfer transaction
- **Offramp processor refactor** — `handleDetected` sets status before calling sub-functions; `handleConvert` and `handleTransfer` own their own `GasTooHighError` catch via a shared `retryOnGas()` helper; switch gains a `CONVERTING` case and `TRANSFERRING` forks on `onChainTxHash` to prevent executions getting stuck with a null hash; all poll/retry limits extended to 5 days
- **Backend Safe architecture idea** documented in `docs/ideas/`

## Test plan
- [ ] Accounting endpoints return correct balances and journal entries
- [ ] Offramp execution with a supported token (USDC/USDT/ETH) progresses through DETECTED → TRANSFERRING → DEPOSITED → SOLD → WITHDRAWING → PENDING_BANK_TRANSFER
- [ ] Offramp execution with an unsupported token (e.g. ZCHF) triggers conversion via 1inch and swap output lands directly at the Kraken deposit address
- [ ] With `MAX_BASE_FEE` set below current network base fee, executions stay in their current status and re-queue every 5 minutes without marking FAILED
- [ ] After resetting a stuck execution to DETECTED via SQL, it resumes correctly on next queue tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)